### PR TITLE
Update travis config to latest node supported by eslint and install peers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,8 @@
-sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.11"
-  - "0.12"
-  - "iojs-1"
-  - "iojs-2"
-  - "iojs-3"
-  - "4"
-matrix:
-  allow_failures:
-    - node_js:
-      - "0.11"
-      - "iojs-1"
-      - "iojs-2"
-      - "iojs-3"
+    - "4"
+    - "5"
+    - "6"
+    - "7"
+sudo: false
+script: "npm test"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-tag-version": "^1.3.0",
     "lazypipe": "^1.0.1",
-    "typescript": "^2.0.10",
+    "typescript": "~2.0.10",
     "typescript-eslint-parser": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-tag-version": "^1.3.0",
     "lazypipe": "^1.0.1",
-    "vinyl-source-stream": "^1.1.0",
-    "typescript-eslint-parser": "^1.0.0"
+    "typescript": "^2.0.10",
+    "typescript-eslint-parser": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0"
   }
 }


### PR DESCRIPTION
Update travis config to latest node supported by eslint and install peers so that typescript will be installed

This should fix failing tests on the other pending PRs
