### PR TITLE
Upgrade: eslint-config-eslint to 4.0.0

### DIFF
--- a/lib/definition.js
+++ b/lib/definition.js
@@ -30,26 +30,32 @@ const Variable = require("./variable");
  */
 class Definition {
     constructor(type, name, node, parent, index, kind) {
+
         /**
          * @member {String} Definition#type - type of the occurrence (e.g. "Parameter", "Variable", ...).
          */
         this.type = type;
+
         /**
          * @member {espree.Identifier} Definition#name - the identifier AST node of the occurrence.
          */
         this.name = name;
+
         /**
          * @member {espree.Node} Definition#node - the enclosing node of the identifier.
          */
         this.node = node;
+
         /**
          * @member {espree.Node?} Definition#parent - the enclosing statement node of the identifier.
          */
         this.parent = parent;
+
         /**
          * @member {Number?} Definition#index - the index in the declaration statement.
          */
         this.index = index;
+
         /**
          * @member {String?} Definition#kind - the kind of the declaration statement.
          */
@@ -63,6 +69,7 @@ class Definition {
 class ParameterDefinition extends Definition {
     constructor(name, node, index, rest) {
         super(Variable.Parameter, name, node, null, index, null);
+
         /**
          * Whether the parameter definition is a part of a rest parameter.
          * @member {boolean} ParameterDefinition#rest

--- a/lib/index.js
+++ b/lib/index.js
@@ -82,7 +82,6 @@ function defaultOptions() {
  * @returns {Object} Updated options
  */
 function updateDeeply(target, override) {
-    var key, val;
 
     /**
      * Is hash object
@@ -93,9 +92,10 @@ function updateDeeply(target, override) {
         return typeof value === "object" && value instanceof Object && !(value instanceof Array) && !(value instanceof RegExp);
     }
 
-    for (key in override) {
+    for (const key in override) {
         if (override.hasOwnProperty(key)) {
-            val = override[key];
+            const val = override[key];
+
             if (isHashObject(val)) {
                 if (isHashObject(target[key])) {
                     updateDeeply(target[key], val);
@@ -131,13 +131,10 @@ function updateDeeply(target, override) {
  * @returns {ScopeManager} ScopeManager
  */
 function analyze(tree, providedOptions) {
-    var scopeManager, referencer, options;
+    const options = updateDeeply(defaultOptions(), providedOptions);
+    const scopeManager = new ScopeManager(options);
+    const referencer = new Referencer(options, scopeManager);
 
-    options = updateDeeply(defaultOptions(), providedOptions);
-
-    scopeManager = new ScopeManager(options);
-
-    referencer = new Referencer(options, scopeManager);
     referencer.visit(tree);
 
     assert(scopeManager.__currentScope === null, "currentScope should be null.");
@@ -146,14 +143,19 @@ function analyze(tree, providedOptions) {
 }
 
 module.exports = {
+
     /** @name module:escope.version */
     version,
+
     /** @name module:escope.Reference */
     Reference,
+
     /** @name module:escope.Variable */
     Variable,
+
     /** @name module:escope.Scope */
     Scope,
+
     /** @name module:escope.ScopeManager */
     ScopeManager,
     analyze

--- a/lib/pattern-visitor.js
+++ b/lib/pattern-visitor.js
@@ -39,7 +39,8 @@ function getLast(xs) {
 
 class PatternVisitor extends esrecurse.Visitor {
     static isPattern(node) {
-        var nodeType = node.type;
+        const nodeType = node.type;
+
         return (
             nodeType === Syntax.Identifier ||
             nodeType === Syntax.ObjectPattern ||
@@ -61,6 +62,7 @@ class PatternVisitor extends esrecurse.Visitor {
 
     Identifier(pattern) {
         const lastRestElement = getLast(this.restElements);
+
         this.callback(pattern, {
             topLevel: pattern === this.rootPattern,
             rest: lastRestElement !== null && lastRestElement !== undefined && lastRestElement.argument === pattern,
@@ -69,6 +71,7 @@ class PatternVisitor extends esrecurse.Visitor {
     }
 
     Property(property) {
+
         // Computed property's key is a right hand node.
         if (property.computed) {
             this.rightHandNodes.push(property.key);
@@ -81,9 +84,9 @@ class PatternVisitor extends esrecurse.Visitor {
     }
 
     ArrayPattern(pattern) {
-        var i, iz, element;
-        for (i = 0, iz = pattern.elements.length; i < iz; ++i) {
-            element = pattern.elements[i];
+        for (let i = 0, iz = pattern.elements.length; i < iz; ++i) {
+            const element = pattern.elements[i];
+
             this.visit(element);
         }
     }
@@ -102,10 +105,12 @@ class PatternVisitor extends esrecurse.Visitor {
     }
 
     MemberExpression(node) {
+
         // Computed property's key is a right hand node.
         if (node.computed) {
             this.rightHandNodes.push(node.property);
         }
+
         // the object is only read, write to its property.
         this.rightHandNodes.push(node.object);
     }
@@ -133,6 +138,7 @@ class PatternVisitor extends esrecurse.Visitor {
     }
 
     CallExpression(node) {
+
         // arguments are right hand nodes.
         node.arguments.forEach(a => {
             this.rightHandNodes.push(a);

--- a/lib/reference.js
+++ b/lib/reference.js
@@ -33,27 +33,32 @@ const RW = READ | WRITE;
  */
 class Reference {
     constructor(ident, scope, flag, writeExpr, maybeImplicitGlobal, partial, init) {
+
         /**
          * Identifier syntax node.
          * @member {espreeIdentifier} Reference#identifier
          */
         this.identifier = ident;
+
         /**
          * Reference to the enclosing Scope.
          * @member {Scope} Reference#from
          */
         this.from = scope;
+
         /**
          * Whether the reference comes from a dynamic scope (such as 'eval',
          * 'with', etc.), and may be trapped by dynamic scopes.
          * @member {boolean} Reference#tainted
          */
         this.tainted = false;
+
         /**
          * The variable this reference is resolved with.
          * @member {Variable} Reference#resolved
          */
         this.resolved = null;
+
         /**
          * The read-write mode of the reference. (Value is one of {@link
          * Reference.READ}, {@link Reference.RW}, {@link Reference.WRITE}).
@@ -62,16 +67,19 @@ class Reference {
          */
         this.flag = flag;
         if (this.isWrite()) {
+
             /**
              * If reference is writeable, this is the tree being written to it.
              * @member {espreeNode} Reference#writeExpr
              */
             this.writeExpr = writeExpr;
+
             /**
              * Whether the Reference might refer to a partial value of writeExpr.
              * @member {boolean} Reference#partial
              */
             this.partial = partial;
+
             /**
              * Whether the Reference is to write of initialization.
              * @member {boolean} Reference#init
@@ -141,11 +149,13 @@ class Reference {
  * @private
  */
 Reference.READ = READ;
+
 /**
  * @constant Reference.WRITE
  * @private
  */
 Reference.WRITE = WRITE;
+
 /**
  * @constant Reference.RW
  * @private

--- a/lib/referencer.js
+++ b/lib/referencer.js
@@ -46,8 +46,10 @@ const Definition = definition.Definition;
  * @returns {void}
  */
 function traverseIdentifierInPattern(options, rootPattern, referencer, callback) {
+
     // Call the callback at left hand identifier nodes, and Collect right hand nodes.
-    var visitor = new PatternVisitor(options, rootPattern, callback);
+    const visitor = new PatternVisitor(options, rootPattern, callback);
+
     visitor.visit(rootPattern);
 
     // Process the right hand nodes recursively.
@@ -70,7 +72,7 @@ class Importer extends esrecurse.Visitor {
     }
 
     visitImport(id, specifier) {
-        this.referencer.visitPattern(id, (pattern) => {
+        this.referencer.visitPattern(id, pattern => {
             this.referencer.currentScope().__define(pattern,
                 new Definition(
                     Variable.ImportBinding,
@@ -84,19 +86,22 @@ class Importer extends esrecurse.Visitor {
     }
 
     ImportNamespaceSpecifier(node) {
-        let local = (node.local || node.id);
+        const local = (node.local || node.id);
+
         if (local) {
             this.visitImport(local, node);
         }
     }
 
     ImportDefaultSpecifier(node) {
-        let local = (node.local || node.id);
+        const local = (node.local || node.id);
+
         this.visitImport(local, node);
     }
 
     ImportSpecifier(node) {
-        let local = (node.local || node.id);
+        const local = (node.local || node.id);
+
         if (node.name) {
             this.visitImport(node.name, node);
         } else {
@@ -126,7 +131,8 @@ class Referencer extends esrecurse.Visitor {
     }
 
     pushInnerMethodDefinition(isInnerMethodDefinition) {
-        var previous = this.isInnerMethodDefinition;
+        const previous = this.isInnerMethodDefinition;
+
         this.isInnerMethodDefinition = isInnerMethodDefinition;
         return previous;
     }
@@ -136,6 +142,7 @@ class Referencer extends esrecurse.Visitor {
     }
 
     materializeTDZScope(node, iterationNode) {
+
         // http://people.mozilla.org/~jorendorff/es6-draft.html#sec-runtime-semantics-forin-div-ofexpressionevaluation-abstract-operation
         // TDZ scope hides the declaration's names.
         this.scopeManager.__nestTDZScope(node, iterationNode);
@@ -143,18 +150,20 @@ class Referencer extends esrecurse.Visitor {
     }
 
     materializeIterationScope(node) {
+
         // Generate iteration scope for upper ForIn/ForOf Statements.
-        var letOrConstDecl;
+        const letOrConstDecl = node.left;
+
         this.scopeManager.__nestForScope(node);
-        letOrConstDecl = node.left;
         this.visitVariableDeclaration(this.currentScope(), Variable.Variable, letOrConstDecl, 0);
-        this.visitPattern(letOrConstDecl.declarations[0].id, (pattern) => {
+        this.visitPattern(letOrConstDecl.declarations[0].id, pattern => {
             this.currentScope().__referencing(pattern, Reference.WRITE, node.right, null, true, true);
         });
     }
 
     referencingDefaultValue(pattern, assignments, maybeImplicitGlobal, init) {
         const scope = this.currentScope();
+
         assignments.forEach(assignment => {
             scope.__referencing(
                 pattern,
@@ -169,7 +178,7 @@ class Referencer extends esrecurse.Visitor {
     visitPattern(node, options, callback) {
         if (typeof options === "function") {
             callback = options;
-            options = {processRightHandNodes: false};
+            options = { processRightHandNodes: false };
         }
         traverseIdentifierInPattern(
             this.options,
@@ -179,13 +188,16 @@ class Referencer extends esrecurse.Visitor {
     }
 
     visitFunction(node) {
-        var i, iz;
+        let i, iz;
+
         // FunctionDeclaration name is defined in upper scope
         // NOTE: Not referring variableScope. It is intended.
         // Since
         //  in ES5, FunctionDeclaration should be in FunctionBody.
         //  in ES6, FunctionDeclaration should be block scoped.
+
         if (node.type === Syntax.FunctionDeclaration) {
+
             // id is defined in upper scope
             this.currentScope().__define(node.id,
                     new Definition(
@@ -208,6 +220,7 @@ class Referencer extends esrecurse.Visitor {
         this.scopeManager.__nestFunctionScope(node, this.isInnerMethodDefinition);
 
         const that = this;
+
         /**
          * Visit pattern callback
          * @param {pattern} pattern - pattern
@@ -228,7 +241,7 @@ class Referencer extends esrecurse.Visitor {
 
         // Process parameter declarations.
         for (i = 0, iz = node.params.length; i < iz; ++i) {
-            this.visitPattern(node.params[i], {processRightHandNodes: true}, visitPatternCallback);
+            this.visitPattern(node.params[i], { processRightHandNodes: true }, visitPatternCallback);
         }
 
         // if there's a rest argument, add that
@@ -236,7 +249,7 @@ class Referencer extends esrecurse.Visitor {
             this.visitPattern({
                 type: "RestElement",
                 argument: node.rest
-            }, (pattern) => {
+            }, pattern => {
                 this.currentScope().__define(pattern,
                     new ParameterDefinition(
                         pattern,
@@ -250,6 +263,7 @@ class Referencer extends esrecurse.Visitor {
         // In TypeScript there are a number of function-like constructs which have no body,
         // so check it exists before traversing
         if (node.body) {
+
             // Skip BlockStatement to prevent creating BlockStatement scope.
             if (node.body.type === Syntax.BlockStatement) {
                 this.visitChildren(node.body);
@@ -293,12 +307,14 @@ class Referencer extends esrecurse.Visitor {
     }
 
     visitProperty(node) {
-        var previous, isMethodDefinition;
+        let previous;
+
         if (node.computed) {
             this.visit(node.key);
         }
 
-        isMethodDefinition = node.type === Syntax.MethodDefinition;
+        const isMethodDefinition = node.type === Syntax.MethodDefinition;
+
         if (isMethodDefinition) {
             previous = this.pushInnerMethodDefinition(true);
         }
@@ -320,16 +336,17 @@ class Referencer extends esrecurse.Visitor {
         } else {
             if (node.left.type === Syntax.VariableDeclaration) {
                 this.visit(node.left);
-                this.visitPattern(node.left.declarations[0].id, (pattern) => {
+                this.visitPattern(node.left.declarations[0].id, pattern => {
                     this.currentScope().__referencing(pattern, Reference.WRITE, node.right, null, true, true);
                 });
             } else {
-                this.visitPattern(node.left, {processRightHandNodes: true}, (pattern, info) => {
-                    var maybeImplicitGlobal = null;
+                this.visitPattern(node.left, { processRightHandNodes: true }, (pattern, info) => {
+                    let maybeImplicitGlobal = null;
+
                     if (!this.currentScope().isStrict) {
                         maybeImplicitGlobal = {
-                            pattern: pattern,
-                            node: node
+                            pattern,
+                            node
                         };
                     }
                     this.referencingDefaultValue(pattern, info.assignments, maybeImplicitGlobal, false);
@@ -342,12 +359,12 @@ class Referencer extends esrecurse.Visitor {
     }
 
     visitVariableDeclaration(variableTargetScope, type, node, index, fromTDZ) {
-        // If this was called to initialize a TDZ scope, this needs to make definitions, but doesn't make references.
-        var decl, init;
 
-        decl = node.declarations[index];
-        init = decl.init;
-        this.visitPattern(decl.id, {processRightHandNodes: !fromTDZ}, (pattern, info) => {
+        // If this was called to initialize a TDZ scope, this needs to make definitions, but doesn't make references.
+        const decl = node.declarations[index];
+        const init = decl.init;
+
+        this.visitPattern(decl.id, { processRightHandNodes: !fromTDZ }, (pattern, info) => {
             variableTargetScope.__define(pattern,
                 new Definition(
                     type,
@@ -370,12 +387,13 @@ class Referencer extends esrecurse.Visitor {
     AssignmentExpression(node) {
         if (PatternVisitor.isPattern(node.left)) {
             if (node.operator === "=") {
-                this.visitPattern(node.left, {processRightHandNodes: true}, (pattern, info) => {
-                    var maybeImplicitGlobal = null;
+                this.visitPattern(node.left, { processRightHandNodes: true }, (pattern, info) => {
+                    let maybeImplicitGlobal = null;
+
                     if (!this.currentScope().isStrict) {
                         maybeImplicitGlobal = {
-                            pattern: pattern,
-                            node: node
+                            pattern,
+                            node
                         };
                     }
                     this.referencingDefaultValue(pattern, info.assignments, maybeImplicitGlobal, false);
@@ -393,7 +411,7 @@ class Referencer extends esrecurse.Visitor {
     CatchClause(node) {
         this.scopeManager.__nestCatchScope(node);
 
-        this.visitPattern(node.param, {processRightHandNodes: true}, (pattern, info) => {
+        this.visitPattern(node.param, { processRightHandNodes: true }, (pattern, info) => {
             this.currentScope().__define(pattern,
                 new Definition(
                     Variable.CatchClause,
@@ -414,6 +432,7 @@ class Referencer extends esrecurse.Visitor {
         this.scopeManager.__nestGlobalScope(node);
 
         if (this.scopeManager.__isNodejsScope()) {
+
             // Force strictness of GlobalScope to false when using node.js scope.
             this.currentScope().isStrict = false;
             this.scopeManager.__nestFunctionScope(node, false);
@@ -458,15 +477,16 @@ class Referencer extends esrecurse.Visitor {
         this.visitProperty(node);
     }
 
-    BreakStatement() {}
+    BreakStatement() {} // eslint-disable-line class-methods-use-this
 
-    ContinueStatement() {}
+    ContinueStatement() {} // eslint-disable-line class-methods-use-this
 
     LabeledStatement(node) {
         this.visit(node.body);
     }
 
     ForStatement(node) {
+
         // Create ForStatement declaration.
         // NOTE: In ES6, ForStatement dynamically generates
         // per iteration environment. However, escope is
@@ -489,8 +509,10 @@ class Referencer extends esrecurse.Visitor {
     }
 
     CallExpression(node) {
+
         // Check this is direct call to eval
         if (!this.scopeManager.__ignoreEval() && node.callee.type === Syntax.Identifier && node.callee.name === "eval") {
+
             // NOTE: This should be `variableScope`. Since direct eval call always creates Lexical environment and
             // let / const should be enclosed into it. Only VariableDeclaration affects on the caller's environment.
             this.currentScope().variableScope.__detectEval();
@@ -514,6 +536,7 @@ class Referencer extends esrecurse.Visitor {
 
     WithStatement(node) {
         this.visit(node.object);
+
         // Then nest scope for WithStatement.
         this.scopeManager.__nestWithScope(node);
 
@@ -523,10 +546,11 @@ class Referencer extends esrecurse.Visitor {
     }
 
     VariableDeclaration(node) {
-        var variableTargetScope, i, iz, decl;
-        variableTargetScope = (node.kind === "var") ? this.currentScope().variableScope : this.currentScope();
-        for (i = 0, iz = node.declarations.length; i < iz; ++i) {
-            decl = node.declarations[i];
+        const variableTargetScope = (node.kind === "var") ? this.currentScope().variableScope : this.currentScope();
+
+        for (let i = 0, iz = node.declarations.length; i < iz; ++i) {
+            const decl = node.declarations[i];
+
             this.visitVariableDeclaration(variableTargetScope, Variable.Variable, node, i);
             if (decl.init) {
                 this.visit(decl.init);
@@ -536,15 +560,13 @@ class Referencer extends esrecurse.Visitor {
 
     // sec 13.11.8
     SwitchStatement(node) {
-        var i, iz;
-
         this.visit(node.discriminant);
 
         if (this.scopeManager.__isES6()) {
             this.scopeManager.__nestSwitchScope(node);
         }
 
-        for (i = 0, iz = node.cases.length; i < iz; ++i) {
+        for (let i = 0, iz = node.cases.length; i < iz; ++i) {
             this.visit(node.cases[i]);
         }
 
@@ -572,11 +594,10 @@ class Referencer extends esrecurse.Visitor {
     }
 
     ImportDeclaration(node) {
-        var importer;
-
         assert(this.scopeManager.__isES6() && this.scopeManager.isModule(), "ImportDeclaration should appear when the mode is ES6 and in the module context.");
 
-        importer = new Importer(node, this);
+        const importer = new Importer(node, this);
+
         importer.visit(node);
     }
 
@@ -601,11 +622,13 @@ class Referencer extends esrecurse.Visitor {
     }
 
     ExportSpecifier(node) {
-        let local = (node.id || node.local);
+        const local = (node.id || node.local);
+
         this.visit(local);
     }
 
-    MetaProperty() {
+    MetaProperty() { // eslint-disable-line class-methods-use-this
+
         // do nothing.
     }
 }

--- a/lib/scope-manager.js
+++ b/lib/scope-manager.js
@@ -108,7 +108,6 @@ class ScopeManager {
      * @returns {Scope?} Scope from node
      */
     acquire(node, inner) {
-        var scopes, scope, i, iz;
 
         /**
          * predicate
@@ -125,7 +124,8 @@ class ScopeManager {
             return true;
         }
 
-        scopes = this.__get(node);
+        const scopes = this.__get(node);
+
         if (!scopes || scopes.length === 0) {
             return null;
         }
@@ -137,15 +137,17 @@ class ScopeManager {
         }
 
         if (inner) {
-            for (i = scopes.length - 1; i >= 0; --i) {
-                scope = scopes[i];
+            for (let i = scopes.length - 1; i >= 0; --i) {
+                const scope = scopes[i];
+
                 if (predicate(scope)) {
                     return scope;
                 }
             }
         } else {
-            for (i = 0, iz = scopes.length; i < iz; ++i) {
-                scope = scopes[i];
+            for (let i = 0, iz = scopes.length; i < iz; ++i) {
+                const scope = scopes[i];
+
                 if (predicate(scope)) {
                     return scope;
                 }
@@ -173,10 +175,11 @@ class ScopeManager {
      * @returns {Scope?} upper scope for the node.
      */
     release(node, inner) {
-        var scopes, scope;
-        scopes = this.__get(node);
+        const scopes = this.__get(node);
+
         if (scopes && scopes.length) {
-            scope = scopes[0].upper;
+            const scope = scopes[0].upper;
+
             if (!scope) {
                 return null;
             }
@@ -185,9 +188,9 @@ class ScopeManager {
         return null;
     }
 
-    attach() { }
+    attach() { } // eslint-disable-line class-methods-use-this
 
-    detach() { }
+    detach() { } // eslint-disable-line class-methods-use-this
 
     __nestScope(scope) {
         if (scope instanceof GlobalScope) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -42,7 +42,7 @@ const assert = require("assert");
  * @returns {boolean} is strict scope
  */
 function isStrictScope(scope, block, isMethodDefinition, useDirective) {
-    var body, i, iz, stmt, expr;
+    let body;
 
     // When upper scope is exists and strict, inner scope is also strict.
     if (scope.upper && scope.upper.isStrict) {
@@ -84,8 +84,9 @@ function isStrictScope(scope, block, isMethodDefinition, useDirective) {
 
     // Search 'use strict' directive.
     if (useDirective) {
-        for (i = 0, iz = body.body.length; i < iz; ++i) {
-            stmt = body.body[i];
+        for (let i = 0, iz = body.body.length; i < iz; ++i) {
+            const stmt = body.body[i];
+
             if (stmt.type !== Syntax.DirectiveStatement) {
                 break;
             }
@@ -94,12 +95,14 @@ function isStrictScope(scope, block, isMethodDefinition, useDirective) {
             }
         }
     } else {
-        for (i = 0, iz = body.body.length; i < iz; ++i) {
-            stmt = body.body[i];
+        for (let i = 0, iz = body.body.length; i < iz; ++i) {
+            const stmt = body.body[i];
+
             if (stmt.type !== Syntax.ExpressionStatement) {
                 break;
             }
-            expr = stmt.expression;
+            const expr = stmt.expression;
+
             if (expr.type !== Syntax.Literal || typeof expr.value !== "string") {
                 break;
             }
@@ -124,15 +127,14 @@ function isStrictScope(scope, block, isMethodDefinition, useDirective) {
  * @returns {void}
  */
 function registerScope(scopeManager, scope) {
-    var scopes;
-
     scopeManager.scopes.push(scope);
 
-    scopes = scopeManager.__nodeToScope.get(scope.block);
+    const scopes = scopeManager.__nodeToScope.get(scope.block);
+
     if (scopes) {
         scopes.push(scope);
     } else {
-        scopeManager.__nodeToScope.set(scope.block, [ scope ]);
+        scopeManager.__nodeToScope.set(scope.block, [scope]);
     }
 }
 
@@ -153,22 +155,26 @@ function shouldBeStatically(def) {
  */
 class Scope {
     constructor(scopeManager, type, upperScope, block, isMethodDefinition) {
+
         /**
          * One of 'TDZ', 'module', 'block', 'switch', 'function', 'catch', 'with', 'function', 'class', 'global'.
          * @member {String} Scope#type
          */
         this.type = type;
+
          /**
          * The scoped {@link Variable}s of this scope, as <code>{ Variable.name
          * : Variable }</code>.
          * @member {Map} Scope#set
          */
         this.set = new Map();
+
         /**
          * The tainted variables of this scope, as <code>{ Variable.name :
          * boolean }</code>.
          * @member {Map} Scope#taints */
         this.taints = new Map();
+
         /**
          * Generally, through the lexical scoping of JS you can always know
          * which variable an identifier in the source code refers to. There are
@@ -180,16 +186,19 @@ class Scope {
          * @member {boolean} Scope#dynamic
          */
         this.dynamic = this.type === "global" || this.type === "with";
+
         /**
          * A reference to the scope-defining syntax node.
          * @member {espree.Node} Scope#block
          */
         this.block = block;
+
          /**
          * The {@link Reference|references} that are not resolved with this scope.
          * @member {Reference[]} Scope#through
          */
         this.through = [];
+
          /**
          * The scoped {@link Variable}s of this scope. In the case of a
          * 'function' scope this includes the automatic argument <em>arguments</em> as
@@ -197,6 +206,7 @@ class Scope {
          * @member {Variable[]} Scope#variables
          */
         this.variables = [];
+
          /**
          * Any variable {@link Reference|reference} found in this scope. This
          * includes occurrences of local variables as well as variables from
@@ -216,16 +226,19 @@ class Scope {
          */
         this.variableScope =
             (this.type === "global" || this.type === "function" || this.type === "module") ? this : upperScope.variableScope;
+
          /**
          * Whether this scope is created by a FunctionExpression.
          * @member {boolean} Scope#functionExpressionScope
          */
         this.functionExpressionScope = false;
+
          /**
          * Whether this is a scope that contains an 'eval()' invocation.
          * @member {boolean} Scope#directCallToEvalScope
          */
         this.directCallToEvalScope = false;
+
          /**
          * @member {boolean} Scope#thisFound
          */
@@ -238,6 +251,7 @@ class Scope {
          * @member {Scope} Scope#upper
          */
         this.upper = upperScope;
+
          /**
          * Whether 'use strict' is in effect in this scope.
          * @member {boolean} Scope#isStrict
@@ -263,14 +277,17 @@ class Scope {
     }
 
     __shouldStaticallyCloseForGlobal(ref) {
+
         // On global scope, let/const/class declarations should be resolved statically.
-        var name = ref.identifier.name;
+        const name = ref.identifier.name;
+
         if (!this.set.has(name)) {
             return false;
         }
 
-        var variable = this.set.get(name);
-        var defs = variable.defs;
+        const variable = this.set.get(name);
+        const defs = variable.defs;
+
         return defs.length > 0 && defs.every(shouldBeStatically);
     }
 
@@ -281,8 +298,10 @@ class Scope {
     }
 
     __dynamicCloseRef(ref) {
+
         // notify all names are through to global
         let current = this;
+
         do {
             current.through.push(ref);
             current = current.upper;
@@ -290,6 +309,7 @@ class Scope {
     }
 
     __globalCloseRef(ref) {
+
         // let/const/class declarations should be resolved statically.
         // others should be resolved dynamically.
         if (this.__shouldStaticallyCloseForGlobal(ref)) {
@@ -300,7 +320,8 @@ class Scope {
     }
 
     __close(scopeManager) {
-        var closeRef;
+        let closeRef;
+
         if (this.__shouldStaticallyClose(scopeManager)) {
             closeRef = this.__staticCloseRef;
         } else if (this.type !== "global") {
@@ -311,7 +332,8 @@ class Scope {
 
         // Try Resolving all references in this scope.
         for (let i = 0, iz = this.__left.length; i < iz; ++i) {
-            let ref = this.__left[i];
+            const ref = this.__left[i];
+
             closeRef.call(this, ref);
         }
         this.__left = null;
@@ -320,10 +342,11 @@ class Scope {
     }
 
     __resolve(ref) {
-        var variable, name;
-        name = ref.identifier.name;
+        const name = ref.identifier.name;
+
         if (this.set.has(name)) {
-            variable = this.set.get(name);
+            const variable = this.set.get(name);
+
             variable.references.push(ref);
             variable.stack = variable.stack && ref.from.variableScope === this.variableScope;
             if (ref.tainted) {
@@ -348,7 +371,8 @@ class Scope {
             return;
         }
 
-        var variables = this.__declaredVariables.get(node);
+        let variables = this.__declaredVariables.get(node);
+
         if (variables === null || variables === undefined) {
             variables = [];
             this.__declaredVariables.set(node, variables);
@@ -359,7 +383,7 @@ class Scope {
     }
 
     __defineGeneric(name, set, variables, node, def) {
-        var variable;
+        let variable;
 
         variable = set.get(name);
         if (!variable) {
@@ -392,6 +416,7 @@ class Scope {
     }
 
     __referencing(node, assign, writeExpr, maybeImplicitGlobal, partial, init) {
+
         // because Array element may be null
         if (!node || node.type !== Syntax.Identifier) {
             return;
@@ -402,14 +427,15 @@ class Scope {
             return;
         }
 
-        let ref = new Reference(node, this, assign || Reference.READ, writeExpr, maybeImplicitGlobal, !!partial, !!init);
+        const ref = new Reference(node, this, assign || Reference.READ, writeExpr, maybeImplicitGlobal, !!partial, !!init);
+
         this.references.push(ref);
         this.__left.push(ref);
     }
 
     __detectEval() {
-        var current;
-        current = this;
+        let current = this;
+
         this.directCallToEvalScope = true;
         do {
             current.dynamic = true;
@@ -432,7 +458,8 @@ class Scope {
      * @returns {Reference} reference
      */
     resolve(ident) {
-        var ref, i, iz;
+        let ref, i, iz;
+
         assert(this.__isClosed(), "Scope should be closed.");
         assert(ident.type === Syntax.Identifier, "Target should be identifier.");
         for (i = 0, iz = this.references.length; i < iz; ++i) {
@@ -458,7 +485,7 @@ class Scope {
      * @method Scope#isArgumentsMaterialized
      * @returns {boolean} arguemnts materialized
      */
-    isArgumentsMaterialized() {
+    isArgumentsMaterialized() { // eslint-disable-line class-methods-use-this
         return true;
     }
 
@@ -467,7 +494,7 @@ class Scope {
      * @method Scope#isThisMaterialized
      * @returns {boolean} this materialized
      */
-    isThisMaterialized() {
+    isThisMaterialized() { // eslint-disable-line class-methods-use-this
         return true;
     }
 
@@ -475,7 +502,7 @@ class Scope {
         if (this.set.has(name)) {
             return true;
         }
-        for (var i = 0, iz = this.through.length; i < iz; ++i) {
+        for (let i = 0, iz = this.through.length; i < iz; ++i) {
             if (this.through[i].identifier.name === name) {
                 return true;
             }
@@ -490,6 +517,7 @@ class GlobalScope extends Scope {
         this.implicit = {
             set: new Map(),
             variables: [],
+
             /**
             * List of {@link Reference}s that are left to be resolved (i.e. which
             * need to be linked to the variable they refer to).
@@ -500,9 +528,11 @@ class GlobalScope extends Scope {
     }
 
     __close(scopeManager) {
-        let implicit = [];
+        const implicit = [];
+
         for (let i = 0, iz = this.__left.length; i < iz; ++i) {
-            let ref = this.__left[i];
+            const ref = this.__left[i];
+
             if (ref.__maybeImplicitGlobal && !this.set.has(ref.identifier.name)) {
                 implicit.push(ref.__maybeImplicitGlobal);
             }
@@ -510,7 +540,8 @@ class GlobalScope extends Scope {
 
         // create an implicit global variable from assignment expression
         for (let i = 0, iz = implicit.length; i < iz; ++i) {
-            let info = implicit[i];
+            const info = implicit[i];
+
             this.__defineImplicit(info.pattern,
                     new Definition(
                         Variable.ImplicitGlobalVariable,
@@ -579,7 +610,8 @@ class WithScope extends Scope {
         }
 
         for (let i = 0, iz = this.__left.length; i < iz; ++i) {
-            let ref = this.__left[i];
+            const ref = this.__left[i];
+
             ref.tainted = true;
             this.__delegateToUpperScope(ref);
         }
@@ -619,6 +651,7 @@ class FunctionScope extends Scope {
     }
 
     isArgumentsMaterialized() {
+
         // TODO(Constellation)
         // We can more aggressive on this condition like this.
         //
@@ -635,7 +668,8 @@ class FunctionScope extends Scope {
             return true;
         }
 
-        let variable = this.set.get("arguments");
+        const variable = this.set.get("arguments");
+
         assert(variable, "Always have arguments variable.");
         return variable.tainted || variable.references.length !== 0;
     }

--- a/lib/variable.js
+++ b/lib/variable.js
@@ -30,17 +30,20 @@
  */
 class Variable {
     constructor(name, scope) {
+
         /**
          * The variable name, as given in the source code.
          * @member {String} Variable#name
          */
         this.name = name;
+
         /**
          * List of defining occurrences of this variable (like in 'var ...'
          * statements or as parameter), as AST nodes.
          * @member {espree.Identifier[]} Variable#identifiers
          */
         this.identifiers = [];
+
         /**
          * List of {@link Reference|references} of this variable (excluding parameter entries)
          * in its defining scope and all nested scopes. For defining
@@ -57,11 +60,13 @@ class Variable {
         this.defs = [];
 
         this.tainted = false;
+
         /**
          * Whether this is a stack variable.
          * @member {boolean} Variable#stack
          */
         this.stack = true;
+
         /**
          * Reference to the enclosing Scope.
          * @member {Scope} Variable#scope

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "eslint": "^3.15.0",
-    "eslint-config-eslint": "^3.0.0",
+    "eslint-config-eslint": "^4.0.0",
     "eslint-release": "^0.10.1",
     "espree": "^3.1.1",
     "istanbul": "^0.4.5",

--- a/tests/arguments.js
+++ b/tests/arguments.js
@@ -28,8 +28,8 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("arguments", function() {
-    it("arguments are correctly materialized", function() {
+describe("arguments", () => {
+    it("arguments are correctly materialized", () => {
         const ast = espree(`
             (function () {
                 arguments;
@@ -37,13 +37,16 @@ describe("arguments", function() {
         `);
 
         const scopeManager = analyze(ast);
+
         expect(scopeManager.scopes).to.have.length(2);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
 
         const scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("function");
         expect(scope.variables).to.have.length(1);
         expect(scope.variables[0].name).to.be.equal("arguments");

--- a/tests/catch-scope.js
+++ b/tests/catch-scope.js
@@ -28,8 +28,8 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("catch", function() {
-    it("creates scope", function() {
+describe("catch", () => {
+    it("creates scope", () => {
         const ast = espree(`
             (function () {
                 try {
@@ -39,13 +39,16 @@ describe("catch", function() {
         `);
 
         const scopeManager = analyze(ast);
+
         expect(scopeManager.scopes).to.have.length(3);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
 
         let scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("function");
         expect(scope.variables).to.have.length(1);
         expect(scope.variables[0].name).to.be.equal("arguments");

--- a/tests/child-visitor-keys.js
+++ b/tests/child-visitor-keys.js
@@ -26,8 +26,8 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("childVisitorKeys option", function() {
-    it("should handle as a known node if the childVisitorKeys option was given.", function() {
+describe("childVisitorKeys option", () => {
+    it("should handle as a known node if the childVisitorKeys option was given.", () => {
         const ast = espree(`
             var foo = 0;
         `);
@@ -46,7 +46,7 @@ describe("childVisitorKeys option", function() {
         );
     });
 
-    it("should not visit to properties which are not given.", function() {
+    it("should not visit to properties which are not given.", () => {
         const ast = espree(`
             let foo = bar;
         `);
@@ -56,7 +56,7 @@ describe("childVisitorKeys option", function() {
             argument: ast.body[0].declarations[0].init
         };
 
-        var result = analyze(
+        const result = analyze(
             ast,
             {
                 childVisitorKeys: {
@@ -72,7 +72,7 @@ describe("childVisitorKeys option", function() {
         expect(globalScope.through).to.have.length(0);
     });
 
-    it("should visit to given properties.", function() {
+    it("should visit to given properties.", () => {
         const ast = espree(`
             let foo = bar;
         `);
@@ -82,7 +82,7 @@ describe("childVisitorKeys option", function() {
             argument: ast.body[0].declarations[0].init
         };
 
-        var result = analyze(
+        const result = analyze(
             ast,
             {
                 childVisitorKeys: {

--- a/tests/es6-arrow-function-expression.js
+++ b/tests/es6-arrow-function-expression.js
@@ -28,8 +28,8 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("ES6 arrow function expression", function() {
-    it("materialize scope for arrow function expression", function() {
+describe("ES6 arrow function expression", () => {
+    it("materialize scope for arrow function expression", () => {
         const ast = espree(`
             var arrow = () => {
                 let i = 0;
@@ -38,10 +38,12 @@ describe("ES6 arrow function expression", function() {
             }
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;
@@ -52,18 +54,21 @@ describe("ES6 arrow function expression", function() {
         expect(scope.block.type).to.be.equal("ArrowFunctionExpression");
         expect(scope.isStrict).to.be.true;
         expect(scope.variables).to.have.length(2);
+
         // There's no "arguments"
         expect(scope.variables[0].name).to.be.equal("i");
         expect(scope.variables[1].name).to.be.equal("j");
     });
 
-    it("generate bindings for parameters", function() {
+    it("generate bindings for parameters", () => {
         const ast = espree("var arrow = (a, b, c, d) => {}");
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;
@@ -74,6 +79,7 @@ describe("ES6 arrow function expression", function() {
         expect(scope.block.type).to.be.equal("ArrowFunctionExpression");
         expect(scope.isStrict).to.be.true;
         expect(scope.variables).to.have.length(4);
+
         // There's no "arguments"
         expect(scope.variables[0].name).to.be.equal("a");
         expect(scope.variables[1].name).to.be.equal("b");

--- a/tests/es6-block-scope.js
+++ b/tests/es6-block-scope.js
@@ -28,8 +28,8 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("ES6 block scope", function() {
-    it("let is materialized in ES6 block scope#1", function() {
+describe("ES6 block scope", () => {
+    it("let is materialized in ES6 block scope#1", () => {
         const ast = espree(`
             {
                 let i = 20;
@@ -37,10 +37,12 @@ describe("ES6 block scope", function() {
             }
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);  // Program and BlcokStatement scope.
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);  // No variable in Program scope.
 
@@ -53,7 +55,7 @@ describe("ES6 block scope", function() {
         expect(scope.references[1].identifier.name).to.be.equal("i");
     });
 
-    it("let is materialized in ES6 block scope#2", function() {
+    it("let is materialized in ES6 block scope#2", () => {
         const ast = espree(`
             {
                 let i = 20;
@@ -62,10 +64,12 @@ describe("ES6 block scope", function() {
             }
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);  // Program and BlcokStatement scope.
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(1);  // No variable in Program scope.
         expect(scope.variables[0].name).to.be.equal("i");
@@ -80,7 +84,7 @@ describe("ES6 block scope", function() {
         expect(scope.references[2].identifier.name).to.be.equal("i");
     });
 
-    it("function delaration is materialized in ES6 block scope", function() {
+    it("function delaration is materialized in ES6 block scope", () => {
         const ast = espree(`
             {
                 function test() {
@@ -89,10 +93,12 @@ describe("ES6 block scope", function() {
             }
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(3);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
 
@@ -110,7 +116,7 @@ describe("ES6 block scope", function() {
         expect(scope.references).to.have.length(0);
     });
 
-    it("let is not hoistable#1", function() {
+    it("let is not hoistable#1", () => {
         const ast = espree(`
             var i = 42; (1)
             {
@@ -120,16 +126,19 @@ describe("ES6 block scope", function() {
             }
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(1);
         expect(globalScope.variables[0].name).to.be.equal("i");
         expect(globalScope.references).to.have.length(1);
 
         const scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("block");
         expect(scope.variables).to.have.length(1);
         expect(scope.variables[0].name).to.be.equal("i");
@@ -139,7 +148,7 @@ describe("ES6 block scope", function() {
         expect(scope.references[2].resolved).to.be.equal(scope.variables[0]);
     });
 
-    it("let is not hoistable#2", function() {
+    it("let is not hoistable#2", () => {
         const ast = espree(`
             (function () {
                 var i = 42; // (1)
@@ -158,20 +167,24 @@ describe("ES6 block scope", function() {
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(4);
 
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
 
         let scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("function");
         expect(scope.variables).to.have.length(2);
         expect(scope.variables[0].name).to.be.equal("arguments");
         expect(scope.variables[1].name).to.be.equal("i");
         const v1 = scope.variables[1];
+
         expect(scope.references).to.have.length(3);
         expect(scope.references[0].resolved).to.be.equal(v1);
         expect(scope.references[1].resolved).to.be.equal(v1);
@@ -182,6 +195,7 @@ describe("ES6 block scope", function() {
         expect(scope.variables).to.have.length(1);
         expect(scope.variables[0].name).to.be.equal("i");
         const v3 = scope.variables[0];
+
         expect(scope.references).to.have.length(3);
         expect(scope.references[0].resolved).to.be.equal(v3);
         expect(scope.references[1].resolved).to.be.equal(v3);
@@ -192,6 +206,7 @@ describe("ES6 block scope", function() {
         expect(scope.variables).to.have.length(1);
         expect(scope.variables[0].name).to.be.equal("i");
         const v2 = scope.variables[0];
+
         expect(scope.references).to.have.length(3);
         expect(scope.references[0].resolved).to.be.equal(v2);
         expect(scope.references[1].resolved).to.be.equal(v2);

--- a/tests/es6-catch.js
+++ b/tests/es6-catch.js
@@ -28,8 +28,8 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("ES6 catch", function() {
-    it("takes binding pattern", function() {
+describe("ES6 catch", () => {
+    it("takes binding pattern", () => {
         const ast = espree(`
             try {
             } catch ({ a, b, c, d }) {
@@ -42,10 +42,12 @@ describe("ES6 catch", function() {
             }
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(4);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;

--- a/tests/es6-class.js
+++ b/tests/es6-class.js
@@ -28,8 +28,8 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("ES6 class", function() {
-    it("declaration name creates class scope", function() {
+describe("ES6 class", () => {
+    it("declaration name creates class scope", () => {
         const ast = espree(`
             class Derived extends Base {
                 constructor() {
@@ -38,10 +38,12 @@ describe("ES6 class", function() {
             new Derived();
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(3);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;
@@ -68,7 +70,7 @@ describe("ES6 class", function() {
         expect(scope.references).to.have.length(0);
     });
 
-    it("expression name creates class scope#1", function() {
+    it("expression name creates class scope#1", () => {
         const ast = espree(`
             (class Derived extends Base {
                 constructor() {
@@ -76,10 +78,12 @@ describe("ES6 class", function() {
             });
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(3);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;
@@ -100,7 +104,7 @@ describe("ES6 class", function() {
         expect(scope.block.type).to.be.equal("FunctionExpression");
     });
 
-    it("expression name creates class scope#2", function() {
+    it("expression name creates class scope#2", () => {
         const ast = espree(`
             (class extends Base {
                 constructor() {
@@ -108,10 +112,12 @@ describe("ES6 class", function() {
             });
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(3);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;
@@ -128,7 +134,7 @@ describe("ES6 class", function() {
         expect(scope.block.type).to.be.equal("FunctionExpression");
     });
 
-    it("computed property key may refer variables", function() {
+    it("computed property key may refer variables", () => {
         const ast = espree(`
             (function () {
                 var yuyushiki = 42;
@@ -142,10 +148,12 @@ describe("ES6 class", function() {
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(5);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;
@@ -170,7 +178,7 @@ describe("ES6 class", function() {
         expect(scope.references[1].identifier.name).to.be.equal("yuyushiki");
     });
 
-    it("regression #49", function() {
+    it("regression #49", () => {
         const ast = espree(`
             class Shoe {
                 constructor() {
@@ -180,10 +188,12 @@ describe("ES6 class", function() {
             let shoe = new Shoe();
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(3);
 
         const scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;

--- a/tests/es6-default-parameters.js
+++ b/tests/es6-default-parameters.js
@@ -29,8 +29,8 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("ES6 default parameters:", function() {
-    describe("a default parameter creates a writable reference for its initialization:", function() {
+describe("ES6 default parameters:", () => {
+    describe("a default parameter creates a writable reference for its initialization:", () => {
         const patterns = {
             FunctionDeclaration: "function foo(a, b = 0) {}",
             FunctionExpression: "let foo = function(a, b = 0) {};",
@@ -39,18 +39,22 @@ describe("ES6 default parameters:", function() {
 
         for (const name in patterns) {
             const code = patterns[name];
-            it(name, function() {
+
+            it(name, () => {
                 const numVars = name === "ArrowExpression" ? 2 : 3;
                 const ast = espree(code);
 
-                const scopeManager = analyze(ast, {ecmaVersion: 6});
+                const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
                 expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
 
                 const scope = scopeManager.scopes[1];
+
                 expect(scope.variables).to.have.length(numVars);  // [arguments?, a, b]
                 expect(scope.references).to.have.length(1);
 
                 const reference = scope.references[0];
+
                 expect(reference.from).to.equal(scope);
                 expect(reference.identifier.name).to.equal("b");
                 expect(reference.resolved).to.equal(scope.variables[numVars - 1]);
@@ -61,7 +65,7 @@ describe("ES6 default parameters:", function() {
         }
     });
 
-    describe("a default parameter creates a readable reference for references in right:", function() {
+    describe("a default parameter creates a readable reference for references in right:", () => {
         const patterns = {
             FunctionDeclaration: `
                 let a;
@@ -79,18 +83,22 @@ describe("ES6 default parameters:", function() {
 
         for (const name in patterns) {
             const code = patterns[name];
-            it(name, function() {
+
+            it(name, () => {
                 const numVars = name === "ArrowExpression" ? 1 : 2;
                 const ast = espree(code);
 
-                const scopeManager = analyze(ast, {ecmaVersion: 6});
+                const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
                 expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
 
                 const scope = scopeManager.scopes[1];
+
                 expect(scope.variables).to.have.length(numVars);  // [arguments?, b]
                 expect(scope.references).to.have.length(2);  // [b, a]
 
                 const reference = scope.references[1];
+
                 expect(reference.from).to.equal(scope);
                 expect(reference.identifier.name).to.equal("a");
                 expect(reference.resolved).to.equal(scopeManager.scopes[0].variables[0]);
@@ -101,7 +109,7 @@ describe("ES6 default parameters:", function() {
         }
     });
 
-    describe("a default parameter creates a readable reference for references in right (for const):", function() {
+    describe("a default parameter creates a readable reference for references in right (for const):", () => {
         const patterns = {
             FunctionDeclaration: `
                 const a = 0;
@@ -119,18 +127,22 @@ describe("ES6 default parameters:", function() {
 
         for (const name in patterns) {
             const code = patterns[name];
-            it(name, function() {
+
+            it(name, () => {
                 const numVars = name === "ArrowExpression" ? 1 : 2;
                 const ast = espree(code);
 
-                const scopeManager = analyze(ast, {ecmaVersion: 6});
+                const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
                 expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
 
                 const scope = scopeManager.scopes[1];
+
                 expect(scope.variables).to.have.length(numVars);  // [arguments?, b]
                 expect(scope.references).to.have.length(2);  // [b, a]
 
                 const reference = scope.references[1];
+
                 expect(reference.from).to.equal(scope);
                 expect(reference.identifier.name).to.equal("a");
                 expect(reference.resolved).to.equal(scopeManager.scopes[0].variables[0]);
@@ -141,7 +153,7 @@ describe("ES6 default parameters:", function() {
         }
     });
 
-    describe("a default parameter creates a readable reference for references in right (partial):", function() {
+    describe("a default parameter creates a readable reference for references in right (partial):", () => {
         const patterns = {
             FunctionDeclaration: `
                 let a;
@@ -159,18 +171,22 @@ describe("ES6 default parameters:", function() {
 
         for (const name in patterns) {
             const code = patterns[name];
-            it(name, function() {
+
+            it(name, () => {
                 const numVars = name === "ArrowExpression" ? 1 : 2;
                 const ast = espree(code);
 
-                const scopeManager = analyze(ast, {ecmaVersion: 6});
+                const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
                 expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
 
                 const scope = scopeManager.scopes[1];
+
                 expect(scope.variables).to.have.length(numVars);  // [arguments?, b]
                 expect(scope.references).to.have.length(2);  // [b, a]
 
                 const reference = scope.references[1];
+
                 expect(reference.from).to.equal(scope);
                 expect(reference.identifier.name).to.equal("a");
                 expect(reference.resolved).to.equal(scopeManager.scopes[0].variables[0]);
@@ -181,7 +197,7 @@ describe("ES6 default parameters:", function() {
         }
     });
 
-    describe("a default parameter creates a readable reference for references in right's nested scope:", function() {
+    describe("a default parameter creates a readable reference for references in right's nested scope:", () => {
         const patterns = {
             FunctionDeclaration: `
                 let a;
@@ -199,17 +215,21 @@ describe("ES6 default parameters:", function() {
 
         for (const name in patterns) {
             const code = patterns[name];
-            it(name, function() {
+
+            it(name, () => {
                 const ast = espree(code);
 
-                const scopeManager = analyze(ast, {ecmaVersion: 6});
+                const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
                 expect(scopeManager.scopes).to.have.length(3);  // [global, foo, anonymous]
 
                 const scope = scopeManager.scopes[2];
+
                 expect(scope.variables).to.have.length(1);  // [arguments]
                 expect(scope.references).to.have.length(1);  // [a]
 
                 const reference = scope.references[0];
+
                 expect(reference.from).to.equal(scope);
                 expect(reference.identifier.name).to.equal("a");
                 expect(reference.resolved).to.equal(scopeManager.scopes[0].variables[0]);

--- a/tests/es6-destructuring-assignments.js
+++ b/tests/es6-destructuring-assignments.js
@@ -28,18 +28,20 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("ES6 destructuring assignments", function() {
-    it("Pattern in var in ForInStatement", function() {
+describe("ES6 destructuring assignments", () => {
+    it("Pattern in var in ForInStatement", () => {
         const ast = espree(`
             (function () {
                 for (var [a, b, c] in array);
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
@@ -70,17 +72,19 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[3].isWrite()).to.be.false;
     });
 
-    it("Pattern in let in ForInStatement", function() {
+    it("Pattern in let in ForInStatement", () => {
         const ast = espree(`
             (function () {
                 for (let [a, b, c] in array);
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(4);  // [global, function, TDZ, for]
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
@@ -118,17 +122,19 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[2].resolved).to.equal(scope.variables[2]);
     });
 
-    it("Pattern with default values in var in ForInStatement", function() {
+    it("Pattern with default values in var in ForInStatement", () => {
         const ast = espree(`
             (function () {
                 for (var [a, b, c = d] in array);
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
@@ -168,17 +174,19 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[5].isWrite()).to.be.false;
     });
 
-    it("Pattern with default values in let in ForInStatement", function() {
+    it("Pattern with default values in let in ForInStatement", () => {
         const ast = espree(`
             (function () {
                 for (let [a, b, c = d] in array);
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(4);  // [global, function, TDZ, for]
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
@@ -229,17 +237,19 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[4].resolved).to.equal(scope.variables[2]);
     });
 
-    it("Pattern with nested default values in var in ForInStatement", function() {
+    it("Pattern with nested default values in var in ForInStatement", () => {
         const ast = espree(`
             (function () {
                 for (var [a, [b, c = d] = e] in array);
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
@@ -294,17 +304,19 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[8].isWrite()).to.be.false;
     });
 
-    it("Pattern with nested default values in let in ForInStatement", function() {
+    it("Pattern with nested default values in let in ForInStatement", () => {
         const ast = espree(`
             (function () {
                 for (let [a, [b, c = d] = e] in array);
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(4);  // [global, function, TDZ, for]
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
@@ -369,7 +381,7 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[7].resolved).to.equal(scope.variables[2]);
     });
 
-    it("Pattern with default values in var in ForInStatement (separate declarations)", function() {
+    it("Pattern with default values in var in ForInStatement (separate declarations)", () => {
         const ast = espree(`
             (function () {
                 var a, b, c;
@@ -377,10 +389,12 @@ describe("ES6 destructuring assignments", function() {
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
@@ -420,7 +434,7 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[5].isWrite()).to.be.false;
     });
 
-    it("Pattern with default values in var in ForInStatement (separate declarations and with MemberExpression)", function() {
+    it("Pattern with default values in var in ForInStatement (separate declarations and with MemberExpression)", () => {
         const ast = espree(`
             (function () {
                 var obj;
@@ -428,10 +442,12 @@ describe("ES6 destructuring assignments", function() {
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
@@ -465,17 +481,19 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[4].isRead()).to.be.true;
     });
 
-    it("ArrayPattern in var", function() {
+    it("ArrayPattern in var", () => {
         const ast = espree(`
             (function () {
                 var [a, b, c] = array;
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
@@ -506,17 +524,19 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[3].isWrite()).to.be.false;
     });
 
-    it("SpreadElement in var", function() {
+    it("SpreadElement in var", () => {
         let ast = espree(`
             (function () {
                 var [a, b, ...rest] = array;
             }());
         `);
 
-        let scopeManager = analyze(ast, {ecmaVersion: 6});
+        let scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
@@ -552,7 +572,7 @@ describe("ES6 destructuring assignments", function() {
             }());
         `);
 
-        scopeManager = analyze(ast, {ecmaVersion: 6});
+        scopeManager = analyze(ast, { ecmaVersion: 6 });
         expect(scopeManager.scopes).to.have.length(2);
 
         scope = scopeManager.scopes[0];
@@ -574,6 +594,7 @@ describe("ES6 destructuring assignments", function() {
             "d",
             "rest"
         ];
+
         for (let index = 0; index < expectedVariableNames.length; index++) {
             expect(scope.variables[index].name).to.be.equal(expectedVariableNames[index]);
         }
@@ -586,6 +607,7 @@ describe("ES6 destructuring assignments", function() {
             "d",
             "rest"
         ];
+
         for (let index = 0; index < expectedReferenceNames.length; index++) {
             expect(scope.references[index].identifier.name).to.be.equal(expectedReferenceNames[index]);
             expect(scope.references[index].isWrite()).to.be.true;
@@ -595,7 +617,7 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[5].isWrite()).to.be.false;
     });
 
-    it("ObjectPattern in var", function() {
+    it("ObjectPattern in var", () => {
         const ast = espree(`
             (function () {
                 var {
@@ -608,10 +630,12 @@ describe("ES6 destructuring assignments", function() {
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
@@ -642,7 +666,7 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[3].isWrite()).to.be.false;
     });
 
-    it("complex pattern in var", function() {
+    it("complex pattern in var", () => {
         const ast = espree(`
             (function () {
                 var {
@@ -655,10 +679,12 @@ describe("ES6 destructuring assignments", function() {
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
@@ -678,6 +704,7 @@ describe("ES6 destructuring assignments", function() {
             "e",
             "world"
         ];
+
         for (let index = 0; index < expectedVariableNames.length; index++) {
             expect(scope.variables[index].name).to.be.equal(expectedVariableNames[index]);
         }
@@ -691,6 +718,7 @@ describe("ES6 destructuring assignments", function() {
             "e",
             "world"
         ];
+
         for (let index = 0; index < expectedReferenceNames.length; index++) {
             expect(scope.references[index].identifier.name).to.be.equal(expectedReferenceNames[index]);
             expect(scope.references[index].isWrite()).to.be.true;
@@ -700,22 +728,24 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[7].isWrite()).to.be.false;
     });
 
-    it("ArrayPattern in AssignmentExpression", function() {
+    it("ArrayPattern in AssignmentExpression", () => {
         const ast = espree(`
             (function () {
                 [a, b, c] = array;
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
         expect(scope.implicit.left).to.have.length(4);
-        expect(scope.implicit.left.map((left) => left.identifier.name)).to.deep.equal([
+        expect(scope.implicit.left.map(left => left.identifier.name)).to.deep.equal([
             "a",
             "b",
             "c",
@@ -743,7 +773,7 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[3].isWrite()).to.be.false;
     });
 
-    it("ArrayPattern with MemberExpression in AssignmentExpression", function() {
+    it("ArrayPattern with MemberExpression in AssignmentExpression", () => {
         const ast = espree(`
             (function () {
                 var obj;
@@ -751,10 +781,12 @@ describe("ES6 destructuring assignments", function() {
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
@@ -784,22 +816,24 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[3].isRead()).to.be.true;
     });
 
-    it("SpreadElement in AssignmentExpression", function() {
+    it("SpreadElement in AssignmentExpression", () => {
         let ast = espree(`
             (function () {
                 [a, b, ...rest] = array;
             }());
         `);
 
-        let scopeManager = analyze(ast, {ecmaVersion: 6});
+        let scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
         expect(scope.implicit.left).to.have.length(4);
-        expect(scope.implicit.left.map((left) => left.identifier.name)).to.deep.equal([
+        expect(scope.implicit.left.map(left => left.identifier.name)).to.deep.equal([
             "a",
             "b",
             "rest",
@@ -832,7 +866,7 @@ describe("ES6 destructuring assignments", function() {
             }());
         `);
 
-        scopeManager = analyze(ast, {ecmaVersion: 6});
+        scopeManager = analyze(ast, { ecmaVersion: 6 });
         expect(scopeManager.scopes).to.have.length(2);
 
         scope = scopeManager.scopes[0];
@@ -840,7 +874,7 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
         expect(scope.implicit.left).to.have.length(6);
-        expect(scope.implicit.left.map((left) => left.identifier.name)).to.deep.equal([
+        expect(scope.implicit.left.map(left => left.identifier.name)).to.deep.equal([
             "a",
             "b",
             "c",
@@ -863,6 +897,7 @@ describe("ES6 destructuring assignments", function() {
             "d",
             "rest"
         ];
+
         for (let index = 0; index < expectedReferenceNames.length; index++) {
             expect(scope.references[index].identifier.name).to.be.equal(expectedReferenceNames[index]);
             expect(scope.references[index].isWrite()).to.be.true;
@@ -873,22 +908,24 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[5].isWrite()).to.be.false;
     });
 
-    it("SpreadElement with MemberExpression in AssignmentExpression", function() {
+    it("SpreadElement with MemberExpression in AssignmentExpression", () => {
         const ast = espree(`
             (function () {
                 [a, b, ...obj.rest] = array;
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
         expect(scope.implicit.left).to.have.length(4);
-        expect(scope.implicit.left.map((left) => left.identifier.name)).to.deep.equal([
+        expect(scope.implicit.left.map(left => left.identifier.name)).to.deep.equal([
             "a",
             "b",
             "obj",
@@ -914,7 +951,7 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[3].isWrite()).to.be.false;
     });
 
-    it("ObjectPattern in AssignmentExpression", function() {
+    it("ObjectPattern in AssignmentExpression", () => {
         const ast = espree(`
             (function () {
                 ({
@@ -927,15 +964,17 @@ describe("ES6 destructuring assignments", function() {
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
         expect(scope.implicit.left).to.have.length(4);
-        expect(scope.implicit.left.map((left) => left.identifier.name)).to.deep.equal([
+        expect(scope.implicit.left.map(left => left.identifier.name)).to.deep.equal([
             "shorthand",
             "value",
             "world",
@@ -963,7 +1002,7 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[3].isWrite()).to.be.false;
     });
 
-    it("complex pattern in AssignmentExpression", function() {
+    it("complex pattern in AssignmentExpression", () => {
         const ast = espree(`
             (function () {
                 ({
@@ -976,15 +1015,17 @@ describe("ES6 destructuring assignments", function() {
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
         expect(scope.implicit.left).to.have.length(8);
-        expect(scope.implicit.left.map((left) => left.identifier.name)).to.deep.equal([
+        expect(scope.implicit.left.map(left => left.identifier.name)).to.deep.equal([
             "shorthand",
             "a",
             "b",
@@ -1009,6 +1050,7 @@ describe("ES6 destructuring assignments", function() {
             "e",
             "world"
         ];
+
         for (let index = 0; index < expectedReferenceNames.length; index++) {
             expect(scope.references[index].identifier.name).to.be.equal(expectedReferenceNames[index]);
             expect(scope.references[index].isWrite()).to.be.true;
@@ -1018,16 +1060,18 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references[7].isWrite()).to.be.false;
     });
 
-    it("ArrayPattern in parameters", function() {
+    it("ArrayPattern in parameters", () => {
         const ast = espree(`
             (function ([a, b, c]) {
             }(array));
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(1);
@@ -1045,16 +1089,18 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references).to.have.length(0);
     });
 
-    it("SpreadElement in parameters", function() {
+    it("SpreadElement in parameters", () => {
         const ast = espree(`
             (function ([a, b, ...rest], ...rest2) {
             }(array));
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(1);
@@ -1075,7 +1121,7 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references).to.have.length(0);
     });
 
-    it("ObjectPattern in parameters", function() {
+    it("ObjectPattern in parameters", () => {
         const ast = espree(`
             (function ({
                     shorthand,
@@ -1087,10 +1133,12 @@ describe("ES6 destructuring assignments", function() {
             }(object));
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(1);
@@ -1108,7 +1156,7 @@ describe("ES6 destructuring assignments", function() {
         expect(scope.references).to.have.length(0);
     });
 
-    it("complex pattern in parameters", function() {
+    it("complex pattern in parameters", () => {
         const ast = espree(`
             (function ({
                     shorthand,
@@ -1120,10 +1168,12 @@ describe("ES6 destructuring assignments", function() {
             }(object));
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(1);
@@ -1144,23 +1194,26 @@ describe("ES6 destructuring assignments", function() {
             "e",
             "world"
         ];
+
         for (let index = 0; index < expectedVariableNames.length; index++) {
             expect(scope.variables[index].name).to.be.equal(expectedVariableNames[index]);
         }
         expect(scope.references).to.have.length(0);
     });
 
-    it("default values and patterns in var", function() {
+    it("default values and patterns in var", () => {
         const ast = espree(`
             (function () {
                 var [a, b, c, d = 20 ] = array;
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
@@ -1175,6 +1228,7 @@ describe("ES6 destructuring assignments", function() {
             "c",
             "d"
         ];
+
         for (let index = 0; index < expectedVariableNames.length; index++) {
             expect(scope.variables[index].name).to.be.equal(expectedVariableNames[index]);
         }
@@ -1187,22 +1241,25 @@ describe("ES6 destructuring assignments", function() {
             "d", // assign array
             "array"
         ];
+
         for (let index = 0; index < expectedReferenceNames.length; index++) {
             expect(scope.references[index].identifier.name).to.be.equal(expectedReferenceNames[index]);
         }
     });
 
-    it("default values containing references and patterns in var", function() {
+    it("default values containing references and patterns in var", () => {
         const ast = espree(`
             (function () {
                 var [a, b, c, d = e ] = array;
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
@@ -1217,6 +1274,7 @@ describe("ES6 destructuring assignments", function() {
             "c",
             "d"
         ];
+
         for (let index = 0; index < expectedVariableNames.length; index++) {
             expect(scope.variables[index].name).to.be.equal(expectedVariableNames[index]);
         }
@@ -1230,22 +1288,25 @@ describe("ES6 destructuring assignments", function() {
             "e",
             "array"
         ];
+
         for (let index = 0; index < expectedReferenceNames.length; index++) {
             expect(scope.references[index].identifier.name).to.be.equal(expectedReferenceNames[index]);
         }
     });
 
-    it("nested default values containing references and patterns in var", function() {
+    it("nested default values containing references and patterns in var", () => {
         const ast = espree(`
             (function () {
                 var [a, b, [c, d = e] = f ] = array;
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.equal("global");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
@@ -1260,6 +1321,7 @@ describe("ES6 destructuring assignments", function() {
             "c",
             "d"
         ];
+
         for (let index = 0; index < expectedVariableNames.length; index++) {
             expect(scope.variables[index].name).to.equal(expectedVariableNames[index]);
         }
@@ -1276,6 +1338,7 @@ describe("ES6 destructuring assignments", function() {
             "f",
             "array"
         ];
+
         for (let index = 0; index < expectedReferenceNames.length; index++) {
             expect(scope.references[index].identifier.name).to.equal(expectedReferenceNames[index]);
         }

--- a/tests/es6-export.js
+++ b/tests/es6-export.js
@@ -26,19 +26,23 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("export declaration", function() {
+describe("export declaration", () => {
+
     // http://people.mozilla.org/~jorendorff/es6-draft.html#sec-static-and-runtme-semantics-module-records
-    it("should create vairable bindings", function() {
+    it("should create vairable bindings", () => {
         const ast = espree("export var v;");
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6, sourceType: "module"});
+        const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "module" });
+
         expect(scopeManager.scopes).to.have.length(2);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
 
         const scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("module");
         expect(scope.variables).to.have.length(1);
         expect(scope.variables[0].name).to.be.equal("v");
@@ -46,17 +50,20 @@ describe("export declaration", function() {
         expect(scope.references).to.have.length(0);
     });
 
-    it("should create function declaration bindings", function() {
+    it("should create function declaration bindings", () => {
         const ast = espree("export default function f(){};");
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6, sourceType: "module"});
+        const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "module" });
+
         expect(scopeManager.scopes).to.have.length(3);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
 
         let scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("module");
         expect(scope.variables).to.have.length(1);
         expect(scope.variables[0].name).to.be.equal("f");
@@ -70,17 +77,20 @@ describe("export declaration", function() {
         expect(scope.references).to.have.length(0);
     });
 
-    it("should export function expression", function() {
+    it("should export function expression", () => {
         const ast = espree("export default function(){};");
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6, sourceType: "module"});
+        const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "module" });
+
         expect(scopeManager.scopes).to.have.length(3);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
 
         let scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("module");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
@@ -92,99 +102,117 @@ describe("export declaration", function() {
         expect(scope.references).to.have.length(0);
     });
 
-    it("should export literal", function() {
+    it("should export literal", () => {
         const ast = espree("export default 42;");
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6, sourceType: "module"});
+        const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "module" });
+
         expect(scopeManager.scopes).to.have.length(2);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
 
         const scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("module");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
     });
 
-    it("should refer exported references#1", function() {
+    it("should refer exported references#1", () => {
         const ast = espree("export {x};");
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6, sourceType: "module"});
+        const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "module" });
+
         expect(scopeManager.scopes).to.have.length(2);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
 
         const scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("module");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(1);
         expect(scope.references[0].identifier.name).to.be.equal("x");
     });
 
-    it("should refer exported references#2", function() {
+    it("should refer exported references#2", () => {
         const ast = espree("export {v as x};");
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6, sourceType: "module"});
+        const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "module" });
+
         expect(scopeManager.scopes).to.have.length(2);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
 
         const scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("module");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(1);
         expect(scope.references[0].identifier.name).to.be.equal("v");
     });
 
-    it("should not refer exported references from other source#1", function() {
+    it("should not refer exported references from other source#1", () => {
         const ast = espree("export {x} from \"mod\";");
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6, sourceType: "module"});
+        const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "module" });
+
         expect(scopeManager.scopes).to.have.length(2);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
 
         const scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("module");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
     });
 
-    it("should not refer exported references from other source#2", function() {
+    it("should not refer exported references from other source#2", () => {
         const ast = espree("export {v as x} from \"mod\";");
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6, sourceType: "module"});
+        const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "module" });
+
         expect(scopeManager.scopes).to.have.length(2);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
 
         const scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("module");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
     });
 
-    it("should not refer exported references from other source#3", function() {
+    it("should not refer exported references from other source#3", () => {
         const ast = espree("export * from \"mod\";");
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6, sourceType: "module"});
+        const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "module" });
+
         expect(scopeManager.scopes).to.have.length(2);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
 
         const scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("module");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);

--- a/tests/es6-import.js
+++ b/tests/es6-import.js
@@ -28,19 +28,23 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("import declaration", function() {
+describe("import declaration", () => {
+
     // http://people.mozilla.org/~jorendorff/es6-draft.html#sec-static-and-runtme-semantics-module-records
-    it("should import names from source", function() {
+    it("should import names from source", () => {
         const ast = espree("import v from \"mod\";");
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6, sourceType: "module"});
+        const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "module" });
+
         expect(scopeManager.scopes).to.have.length(2);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
 
         const scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("module");
         expect(scope.isStrict).to.be.true;
         expect(scope.variables).to.have.length(1);
@@ -49,17 +53,20 @@ describe("import declaration", function() {
         expect(scope.references).to.have.length(0);
     });
 
-    it("should import namespaces", function() {
+    it("should import namespaces", () => {
         const ast = espree("import * as ns from \"mod\";");
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6, sourceType: "module"});
+        const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "module" });
+
         expect(scopeManager.scopes).to.have.length(2);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
 
         const scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("module");
         expect(scope.isStrict).to.be.true;
         expect(scope.variables).to.have.length(1);
@@ -68,17 +75,20 @@ describe("import declaration", function() {
         expect(scope.references).to.have.length(0);
     });
 
-    it("should import insided names#1", function() {
+    it("should import insided names#1", () => {
         const ast = espree("import {x} from \"mod\";");
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6, sourceType: "module"});
+        const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "module" });
+
         expect(scopeManager.scopes).to.have.length(2);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
 
         const scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("module");
         expect(scope.isStrict).to.be.true;
         expect(scope.variables).to.have.length(1);
@@ -87,17 +97,20 @@ describe("import declaration", function() {
         expect(scope.references).to.have.length(0);
     });
 
-    it("should import insided names#2", function() {
+    it("should import insided names#2", () => {
         const ast = espree("import {x as v} from \"mod\";");
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6, sourceType: "module"});
+        const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "module" });
+
         expect(scopeManager.scopes).to.have.length(2);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
 
         const scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("module");
         expect(scope.isStrict).to.be.true;
         expect(scope.variables).to.have.length(1);

--- a/tests/es6-iteration-scope.js
+++ b/tests/es6-iteration-scope.js
@@ -28,8 +28,8 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("ES6 iteration scope", function() {
-    it("let materialize iteration scope for ForInStatement#1", function() {
+describe("ES6 iteration scope", () => {
+    it("let materialize iteration scope for ForInStatement#1", () => {
         const ast = espree(`
             (function () {
                 let i = 20;
@@ -39,10 +39,12 @@ describe("ES6 iteration scope", function() {
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(5);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
 
@@ -56,6 +58,7 @@ describe("ES6 iteration scope", function() {
         expect(scope.references[0].resolved).to.be.equal(scope.variables[1]);
 
         let iterScope = scope = scopeManager.scopes[2];
+
         expect(scope.type).to.be.equal("TDZ");
         expect(scope.variables).to.have.length(1);
         expect(scope.variables[0].name).to.be.equal("i");
@@ -82,7 +85,7 @@ describe("ES6 iteration scope", function() {
         expect(scope.references[1].resolved).to.be.equal(iterScope.variables[0]);
     });
 
-    it("let materialize iteration scope for ForInStatement#2", function() {
+    it("let materialize iteration scope for ForInStatement#2", () => {
         const ast = espree(`
             (function () {
                 let i = 20;
@@ -92,10 +95,12 @@ describe("ES6 iteration scope", function() {
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(5);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
 
@@ -109,6 +114,7 @@ describe("ES6 iteration scope", function() {
         expect(scope.references[0].resolved).to.be.equal(scope.variables[1]);
 
         let iterScope = scope = scopeManager.scopes[2];
+
         expect(scope.type).to.be.equal("TDZ");
         expect(scope.variables).to.have.length(3);
         expect(scope.variables[0].name).to.be.equal("i");
@@ -145,7 +151,7 @@ describe("ES6 iteration scope", function() {
         expect(scope.references[1].resolved).to.be.equal(iterScope.variables[0]);
     });
 
-    it("let materialize iteration scope for ForStatement#2", function() {
+    it("let materialize iteration scope for ForStatement#2", () => {
         const ast = espree(`
             (function () {
                 let i = 20;
@@ -156,14 +162,17 @@ describe("ES6 iteration scope", function() {
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(4);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(0);
 
         const functionScope = scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("function");
         expect(scope.variables).to.have.length(3);
         expect(scope.variables[0].name).to.be.equal("arguments");
@@ -176,6 +185,7 @@ describe("ES6 iteration scope", function() {
         expect(scope.references[1].resolved).to.be.equal(scope.variables[2]);
 
         const iterScope = scope = scopeManager.scopes[2];
+
         expect(scope.type).to.be.equal("for");
         expect(scope.variables).to.have.length(3);
         expect(scope.variables[0].name).to.be.equal("i");

--- a/tests/es6-new-target.js
+++ b/tests/es6-new-target.js
@@ -28,8 +28,8 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("ES6 new.target", function() {
-    it("should not make references of new.target", function() {
+describe("ES6 new.target", () => {
+    it("should not make references of new.target", () => {
         const ast = espree(`
             class A {
                 constructor() {
@@ -38,10 +38,12 @@ describe("ES6 new.target", function() {
             }
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(3);
 
         const scope = scopeManager.scopes[2];
+
         expect(scope.type).to.be.equal("function");
         expect(scope.block.type).to.be.equal("FunctionExpression");
         expect(scope.isStrict).to.be.true;

--- a/tests/es6-object.js
+++ b/tests/es6-object.js
@@ -28,18 +28,20 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("ES6 object", function() {
-    it("method definition", function() {
+describe("ES6 object", () => {
+    it("method definition", () => {
         const ast = espree(`
             ({
                 constructor() {
                 }
             })`);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;
@@ -53,7 +55,7 @@ describe("ES6 object", function() {
         expect(scope.references).to.have.length(0);
     });
 
-    it("computed property key may refer variables", function() {
+    it("computed property key may refer variables", () => {
         const ast = espree(`
             (function () {
                 var yuyushiki = 42;
@@ -67,10 +69,12 @@ describe("ES6 object", function() {
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(4);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;

--- a/tests/es6-rest-args.js
+++ b/tests/es6-rest-args.js
@@ -28,18 +28,20 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("ES6 rest arguments", function() {
-    it("materialize rest argument in scope", function() {
+describe("ES6 rest arguments", () => {
+    it("materialize rest argument in scope", () => {
         const ast = espree(`
             function foo(...bar) {
                 return bar;
             }
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;

--- a/tests/es6-super.js
+++ b/tests/es6-super.js
@@ -26,8 +26,8 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("ES6 super", function() {
-    it("is not handled as reference", function() {
+describe("ES6 super", () => {
+    it("is not handled as reference", () => {
         const ast = espree(`
             class Hello {
                 constructor() {
@@ -40,10 +40,12 @@ describe("ES6 super", function() {
             }
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(4);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(1);
         expect(scope.variables[0].name).to.be.equal("Hello");

--- a/tests/es6-switch.js
+++ b/tests/es6-switch.js
@@ -28,8 +28,8 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("ES6 switch", function() {
-    it("materialize scope", function() {
+describe("ES6 switch", () => {
+    it("materialize scope", () => {
         const ast = espree(`
             switch (ok) {
                 case hello:
@@ -43,10 +43,12 @@ describe("ES6 switch", function() {
             }
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;

--- a/tests/es6-template-literal.js
+++ b/tests/es6-template-literal.js
@@ -28,8 +28,8 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("ES6 template literal", function() {
-    it("refer variables", function() {
+describe("ES6 template literal", () => {
+    it("refer variables", () => {
         const ast = espree(`
             (function () {
                 let i, j, k;
@@ -39,10 +39,12 @@ describe("ES6 template literal", function() {
             }());
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6});
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
         expect(scopeManager.scopes).to.have.length(3);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;

--- a/tests/fallback.js
+++ b/tests/fallback.js
@@ -27,20 +27,20 @@ const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
 
-describe("fallback option", function() {
-    it("should raise an error when it encountered an unknown node if no fallback.", function() {
+describe("fallback option", () => {
+    it("should raise an error when it encountered an unknown node if no fallback.", () => {
         const ast = espree(`
             var foo = 0;
         `);
 
         ast.body[0].declarations[0].init.type = "NumericLiteral";
 
-        expect(function() {
-            analyze(ast, {fallback: "none"});
+        expect(() => {
+            analyze(ast, { fallback: "none" });
         }).to.throw("Unknown node type NumericLiteral");
     });
 
-    it("should not raise an error even if it encountered an unknown node when fallback is iteration.", function() {
+    it("should not raise an error even if it encountered an unknown node when fallback is iteration.", () => {
         const ast = espree(`
             var foo = 0;
         `);
@@ -48,17 +48,17 @@ describe("fallback option", function() {
         ast.body[0].declarations[0].init.type = "NumericLiteral";
 
         analyze(ast); // default is `fallback: "iteration"`
-        analyze(ast, {fallback: "iteration"});
+        analyze(ast, { fallback: "iteration" });
     });
 
-    it("should not raise an error even if it encountered an unknown node when fallback is a function.", function() {
+    it("should not raise an error even if it encountered an unknown node when fallback is a function.", () => {
         const ast = espree(`
             var foo = 0;
         `);
 
         ast.body[0].declarations[0].init.type = "NumericLiteral";
 
-        analyze(ast, {fallback: node => Object.keys(node)});
+        analyze(ast, { fallback: node => Object.keys(node) });
     });
 });
 

--- a/tests/function-expression-name.js
+++ b/tests/function-expression-name.js
@@ -28,16 +28,18 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("function name", function() {
-    it("should create its special scope", function() {
+describe("function name", () => {
+    it("should create its special scope", () => {
         const ast = espree(`
             (function name() {
             }());
         `);
 
         const scopeManager = analyze(ast);
+
         expect(scopeManager.scopes).to.have.length(3);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
@@ -45,6 +47,7 @@ describe("function name", function() {
 
         // Function expression name scope
         let scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("function-expression-name");
         expect(scope.variables).to.have.length(1);
         expect(scope.variables[0].name).to.be.equal("name");

--- a/tests/get-declared-variables.js
+++ b/tests/get-declared-variables.js
@@ -27,7 +27,7 @@ const visit = require("esrecurse").visit;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("ScopeManager.prototype.getDeclaredVariables", function() {
+describe("ScopeManager.prototype.getDeclaredVariables", () => {
     /* eslint-disable require-jsdoc */
     function verify(ast, type, expectedNamesList) {
         const scopeManager = analyze(ast, {
@@ -43,6 +43,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", function() {
                 expect(actual).to.have.length(expected.length);
                 if (actual.length > 0) {
                     const end = actual.length - 1;
+
                     for (let i = 0; i <= end; i++) {
                         expect(actual[i].name).to.be.equal(expected[i]);
                     }
@@ -55,7 +56,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", function() {
         expect(expectedNamesList).to.have.length(0);
     }
 
-    it("should get variables that declared on `VariableDeclaration`", function() {
+    it("should get variables that declared on `VariableDeclaration`", () => {
         const ast = espree(`
             var {a, x: [b], y: {c = 0}} = foo;
             let {d, x: [e], y: {f = 0}} = foo;
@@ -71,7 +72,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", function() {
     });
 
 
-    it("should get variables that declared on `VariableDeclaration` in for-in/of", function() {
+    it("should get variables that declared on `VariableDeclaration` in for-in/of", () => {
         const ast = espree(`
             for (var {a, x: [b], y: {c = 0}} in foo) {
                 let g;
@@ -90,7 +91,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", function() {
     });
 
 
-    it("should get variables that declared on `VariableDeclarator`", function() {
+    it("should get variables that declared on `VariableDeclarator`", () => {
         const ast = espree(`
             var {a, x: [b], y: {c = 0}} = foo;
             let {d, x: [e], y: {f = 0}} = foo;
@@ -107,7 +108,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", function() {
     });
 
 
-    it("should get variables that declared on `FunctionDeclaration`", function() {
+    it("should get variables that declared on `FunctionDeclaration`", () => {
         const ast = espree(`
             function foo({a, x: [b], y: {c = 0}}, [d, e]) {
                 let z;
@@ -124,7 +125,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", function() {
     });
 
 
-    it("should get variables that declared on `FunctionExpression`", function() {
+    it("should get variables that declared on `FunctionExpression`", () => {
         const ast = espree(`
             (function foo({a, x: [b], y: {c = 0}}, [d, e]) {
                 let z;
@@ -142,7 +143,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", function() {
     });
 
 
-    it("should get variables that declared on `ArrowFunctionExpression`", function() {
+    it("should get variables that declared on `ArrowFunctionExpression`", () => {
         const ast = espree(`
             (({a, x: [b], y: {c = 0}}, [d, e]) => {
                 let z;
@@ -159,7 +160,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", function() {
     });
 
 
-    it("should get variables that declared on `ClassDeclaration`", function() {
+    it("should get variables that declared on `ClassDeclaration`", () => {
         const ast = espree(`
             class A { foo(x) { let y; } }
             class B { foo(x) { let y; } }
@@ -172,7 +173,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", function() {
     });
 
 
-    it("should get variables that declared on `ClassExpression`", function() {
+    it("should get variables that declared on `ClassExpression`", () => {
         const ast = espree(`
             (class A { foo(x) { let y; } });
             (class B { foo(x) { let y; } });
@@ -185,7 +186,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", function() {
     });
 
 
-    it("should get variables that declared on `CatchClause`", function() {
+    it("should get variables that declared on `CatchClause`", () => {
         const ast = espree(`
             try {} catch ({a, b}) {
                 let x;
@@ -202,7 +203,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", function() {
     });
 
 
-    it("should get variables that declared on `ImportDeclaration`", function() {
+    it("should get variables that declared on `ImportDeclaration`", () => {
         const ast = espree(`
             import "aaa";
             import * as a from "bbb";
@@ -217,7 +218,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", function() {
     });
 
 
-    it("should get variables that declared on `ImportSpecifier`", function() {
+    it("should get variables that declared on `ImportSpecifier`", () => {
         const ast = espree(`
             import "aaa";
             import * as a from "bbb";
@@ -231,7 +232,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", function() {
     });
 
 
-    it("should get variables that declared on `ImportDefaultSpecifier`", function() {
+    it("should get variables that declared on `ImportDefaultSpecifier`", () => {
         const ast = espree(`
             import "aaa";
             import * as a from "bbb";
@@ -244,7 +245,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", function() {
     });
 
 
-    it("should get variables that declared on `ImportNamespaceSpecifier`", function() {
+    it("should get variables that declared on `ImportNamespaceSpecifier`", () => {
         const ast = espree(`
             import "aaa";
             import * as a from "bbb";
@@ -257,7 +258,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", function() {
     });
 
 
-    it("should not get duplicate even if it's declared twice", function() {
+    it("should not get duplicate even if it's declared twice", () => {
         const ast = espree("var a = 0, a = 1;");
 
         verify(ast, "VariableDeclaration", [

--- a/tests/global-increment.js
+++ b/tests/global-increment.js
@@ -28,13 +28,15 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("global increment", function() {
-    it("becomes read/write", function() {
+describe("global increment", () => {
+    it("becomes read/write", () => {
         const ast = espree("b++;");
 
         const scopeManager = analyze(ast);
+
         expect(scopeManager.scopes).to.have.length(1);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(1);

--- a/tests/implicit-global-reference.js
+++ b/tests/implicit-global-reference.js
@@ -25,8 +25,8 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("implicit global reference", function() {
-    it("assignments global scope", function() {
+describe("implicit global reference", () => {
+    it("assignments global scope", () => {
         const ast = espree(`
             var x = 20;
             x = 300;
@@ -47,7 +47,7 @@ describe("implicit global reference", function() {
         expect(scopes[0].implicit.variables.map(variable => variable.name)).to.be.eql([]);
     });
 
-    it("assignments global scope without definition", function() {
+    it("assignments global scope without definition", () => {
         const ast = espree(`
             x = 300;
             x = 300;
@@ -69,7 +69,7 @@ describe("implicit global reference", function() {
         );
     });
 
-    it("assignments global scope without definition eval", function() {
+    it("assignments global scope without definition eval", () => {
         const ast = espree(`
             function inner() {
                 eval(str);
@@ -96,7 +96,7 @@ describe("implicit global reference", function() {
         expect(scopes[0].implicit.variables.map(variable => variable.name)).to.be.eql([]);
     });
 
-    it("assignment leaks", function() {
+    it("assignment leaks", () => {
         const ast = espree(`
             function outer() {
                 x = 20;
@@ -123,7 +123,7 @@ describe("implicit global reference", function() {
         );
     });
 
-    it("assignment doesn\'t leak", function() {
+    it("assignment doesn't leak", () => {
         const ast = espree(`
             function outer() {
                 function inner() {
@@ -154,7 +154,7 @@ describe("implicit global reference", function() {
         expect(scopes[0].implicit.variables.map(variable => variable.name)).to.be.eql([]);
     });
 
-    it("for-in-statement leaks", function() {
+    it("for-in-statement leaks", () => {
         const ast = espree(`
             function outer() {
                 for (x in y) { }
@@ -180,7 +180,7 @@ describe("implicit global reference", function() {
         );
     });
 
-    it("for-in-statement doesn\'t leaks", function() {
+    it("for-in-statement doesn't leaks", () => {
         const ast = espree(`
             function outer() {
                 function inner() {

--- a/tests/implied-strict.js
+++ b/tests/implied-strict.js
@@ -28,8 +28,8 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("impliedStrict option", function() {
-    it("ensures all user scopes are strict if ecmaVersion >= 5", function() {
+describe("impliedStrict option", () => {
+    it("ensures all user scopes are strict if ecmaVersion >= 5", () => {
         const ast = espree(`
             function foo() {
                 function bar() {
@@ -38,10 +38,12 @@ describe("impliedStrict option", function() {
             }
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 5, impliedStrict: true});
+        const scopeManager = analyze(ast, { ecmaVersion: 5, impliedStrict: true });
+
         expect(scopeManager.scopes).to.have.length(3);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.true;
@@ -57,15 +59,17 @@ describe("impliedStrict option", function() {
         expect(scope.isStrict).to.be.true;
     });
 
-    it("ensures impliedStrict option is only effective when ecmaVersion option >= 5", function() {
+    it("ensures impliedStrict option is only effective when ecmaVersion option >= 5", () => {
         const ast = espree(`
             function foo() {}
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 3, impliedStrict: true});
+        const scopeManager = analyze(ast, { ecmaVersion: 3, impliedStrict: true });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;
@@ -76,15 +80,17 @@ describe("impliedStrict option", function() {
         expect(scope.isStrict).to.be.false;
     });
 
-    it("omits a nodejs global scope when ensuring all user scopes are strict", function() {
+    it("omits a nodejs global scope when ensuring all user scopes are strict", () => {
         const ast = espree(`
             function foo() {}
         `);
 
-        let scopeManager = analyze(ast, {ecmaVersion: 5, nodejsScope: true, impliedStrict: true});
+        const scopeManager = analyze(ast, { ecmaVersion: 5, nodejsScope: true, impliedStrict: true });
+
         expect(scopeManager.scopes).to.have.length(3);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;
@@ -100,15 +106,17 @@ describe("impliedStrict option", function() {
         expect(scope.isStrict).to.be.true;
     });
 
-    it("omits a module global scope when ensuring all user scopes are strict", function() {
+    it("omits a module global scope when ensuring all user scopes are strict", () => {
         const ast = espree(`
             function foo() {}`
         );
 
-        let scopeManager = analyze(ast, {ecmaVersion: 6, impliedStrict: true, sourceType: "module"});
+        const scopeManager = analyze(ast, { ecmaVersion: 6, impliedStrict: true, sourceType: "module" });
+
         expect(scopeManager.scopes).to.have.length(3);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;

--- a/tests/label.js
+++ b/tests/label.js
@@ -28,19 +28,22 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("label", function() {
-    it("should not create variables", function() {
+describe("label", () => {
+    it("should not create variables", () => {
         const ast = espree("function bar() { q: for(;;) { break q; } }");
 
         const scopeManager = analyze(ast);
+
         expect(scopeManager.scopes).to.have.length(2);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(1);
         expect(globalScope.variables[0].name).to.be.equal("bar");
         expect(globalScope.references).to.have.length(0);
 
         const scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("function");
         expect(scope.variables).to.have.length(1);
         expect(scope.variables[0].name).to.be.equal("arguments");
@@ -48,7 +51,7 @@ describe("label", function() {
         expect(scope.references).to.have.length(0);
     });
 
-    it("should count child node references", function() {
+    it("should count child node references", () => {
         const ast = espree(`
             var foo = 5;
 
@@ -59,8 +62,10 @@ describe("label", function() {
         `);
 
         const scopeManager = analyze(ast);
+
         expect(scopeManager.scopes).to.have.length(1);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(1);
         expect(globalScope.variables[0].name).to.be.equal("foo");

--- a/tests/nodejs-scope.js
+++ b/tests/nodejs-scope.js
@@ -28,17 +28,19 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("nodejsScope option", function() {
-    it("creates a function scope following the global scope immediately", function() {
+describe("nodejsScope option", () => {
+    it("creates a function scope following the global scope immediately", () => {
         const ast = espree(`
             "use strict";
             var hello = 20;
         `);
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6, nodejsScope: true});
+        const scopeManager = analyze(ast, { ecmaVersion: 6, nodejsScope: true });
+
         expect(scopeManager.scopes).to.have.length(2);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;
@@ -53,15 +55,17 @@ describe("nodejsScope option", function() {
         expect(scope.variables[1].name).to.be.equal("hello");
     });
 
-    it("creates a function scope following the global scope immediately and creates module scope", function() {
+    it("creates a function scope following the global scope immediately and creates module scope", () => {
         const ast = espree(`
             import {x as v} from "mod";`
         );
 
-        const scopeManager = analyze(ast, {ecmaVersion: 6, nodejsScope: true, sourceType: "module"});
+        const scopeManager = analyze(ast, { ecmaVersion: 6, nodejsScope: true, sourceType: "module" });
+
         expect(scopeManager.scopes).to.have.length(3);
 
         let scope = scopeManager.scopes[0];
+
         expect(scope.type).to.be.equal("global");
         expect(scope.block.type).to.be.equal("Program");
         expect(scope.isStrict).to.be.false;

--- a/tests/object-expression.js
+++ b/tests/object-expression.js
@@ -3,8 +3,9 @@
 const expect = require("chai").expect;
 const analyze = require("..").analyze;
 
-describe("object expression", function() {
-    it("doesn\'t require property type", function() {
+describe("object expression", () => {
+    it("doesn't require property type", () => {
+
         // Hardcoded AST.  Escope adds an extra "Property"
         // key/value to ObjectExpressions, so we're not using
         // it parse a program string.
@@ -37,6 +38,7 @@ describe("object expression", function() {
         };
 
         const scope = analyze(ast).scopes[0];
+
         expect(scope.variables).to.have.length(1);
         expect(scope.references).to.have.length(2);
         expect(scope.variables[0].name).to.be.equal("a");

--- a/tests/optimistic.js
+++ b/tests/optimistic.js
@@ -25,8 +25,8 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("optimistic", function() {
-    it("direct call to eval", function() {
+describe("optimistic", () => {
+    it("direct call to eval", () => {
         const ast = espree(`
             function outer() {
                 eval(str);
@@ -37,7 +37,7 @@ describe("optimistic", function() {
             }
         `);
 
-        const scopes = analyze(ast, {optimistic: true}).scopes;
+        const scopes = analyze(ast, { optimistic: true }).scopes;
 
         expect(scopes.map(scope => scope.variables.map(variable => variable.name))).to.be.eql(
             [
@@ -56,7 +56,7 @@ describe("optimistic", function() {
         );
     });
 
-    it("with statement", function() {
+    it("with statement", () => {
         const ast = espree(`
             function outer() {
                 eval(str);
@@ -67,7 +67,7 @@ describe("optimistic", function() {
             }
         `, "script");
 
-        const scopes = analyze(ast, {optimistic: true}).scopes;
+        const scopes = analyze(ast, { optimistic: true }).scopes;
 
         expect(scopes.map(scope => scope.variables.map(variable => variable.name))).to.be.eql(
             [

--- a/tests/references.js
+++ b/tests/references.js
@@ -28,19 +28,22 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("References:", function() {
-    describe("When there is a `let` declaration on global,", function() {
-        it("the reference on global should be resolved.", function() {
+describe("References:", () => {
+    describe("When there is a `let` declaration on global,", () => {
+        it("the reference on global should be resolved.", () => {
             const ast = espree("let a = 0;");
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(1);
 
             const scope = scopeManager.scopes[0];
+
             expect(scope.variables).to.have.length(1);
             expect(scope.references).to.have.length(1);
 
             const reference = scope.references[0];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("a");
             expect(reference.resolved).to.equal(scope.variables[0]);
@@ -49,7 +52,7 @@ describe("References:", function() {
             expect(reference.isRead()).to.be.false;
         });
 
-        it("the reference in functions should be resolved.", function() {
+        it("the reference in functions should be resolved.", () => {
             const ast = espree(`
                 let a = 0;
                 function foo() {
@@ -57,14 +60,17 @@ describe("References:", function() {
                 }
             `);
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
 
             const scope = scopeManager.scopes[1];
+
             expect(scope.variables).to.have.length(2);  // [arguments, b]
             expect(scope.references).to.have.length(2);  // [b, a]
 
             const reference = scope.references[1];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("a");
             expect(reference.resolved).to.equal(scopeManager.scopes[0].variables[0]);
@@ -73,21 +79,24 @@ describe("References:", function() {
             expect(reference.isRead()).to.be.true;
         });
 
-        it("the reference in default parameters should be resolved.", function() {
+        it("the reference in default parameters should be resolved.", () => {
             const ast = espree(`
                 let a = 0;
                 function foo(b = a) {
                 }
             `);
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
 
             const scope = scopeManager.scopes[1];
+
             expect(scope.variables).to.have.length(2);  // [arguments, b]
             expect(scope.references).to.have.length(2);  // [b, a]
 
             const reference = scope.references[1];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("a");
             expect(reference.resolved).to.equal(scopeManager.scopes[0].variables[0]);
@@ -97,18 +106,21 @@ describe("References:", function() {
         });
     });
 
-    describe("When there is a `const` declaration on global,", function() {
-        it("the reference on global should be resolved.", function() {
+    describe("When there is a `const` declaration on global,", () => {
+        it("the reference on global should be resolved.", () => {
             const ast = espree("const a = 0;");
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(1);
 
             const scope = scopeManager.scopes[0];
+
             expect(scope.variables).to.have.length(1);
             expect(scope.references).to.have.length(1);
 
             const reference = scope.references[0];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("a");
             expect(reference.resolved).to.equal(scope.variables[0]);
@@ -117,7 +129,7 @@ describe("References:", function() {
             expect(reference.isRead()).to.be.false;
         });
 
-        it("the reference in functions should be resolved.", function() {
+        it("the reference in functions should be resolved.", () => {
             const ast = espree(`
                 const a = 0;
                 function foo() {
@@ -125,14 +137,17 @@ describe("References:", function() {
                 }
             `);
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
 
             const scope = scopeManager.scopes[1];
+
             expect(scope.variables).to.have.length(2);  // [arguments, b]
             expect(scope.references).to.have.length(2);  // [b, a]
 
             const reference = scope.references[1];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("a");
             expect(reference.resolved).to.equal(scopeManager.scopes[0].variables[0]);
@@ -142,18 +157,21 @@ describe("References:", function() {
         });
     });
 
-    describe("When there is a `var` declaration on global,", function() {
-        it("the reference on global should NOT be resolved.", function() {
+    describe("When there is a `var` declaration on global,", () => {
+        it("the reference on global should NOT be resolved.", () => {
             const ast = espree("var a = 0;");
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(1);
 
             const scope = scopeManager.scopes[0];
+
             expect(scope.variables).to.have.length(1);
             expect(scope.references).to.have.length(1);
 
             const reference = scope.references[0];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("a");
             expect(reference.resolved).to.be.null;
@@ -162,7 +180,7 @@ describe("References:", function() {
             expect(reference.isRead()).to.be.false;
         });
 
-        it("the reference in functions should NOT be resolved.", function() {
+        it("the reference in functions should NOT be resolved.", () => {
             const ast = espree(`
                 var a = 0;
                 function foo() {
@@ -170,14 +188,17 @@ describe("References:", function() {
                 }
             `);
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
 
             const scope = scopeManager.scopes[1];
+
             expect(scope.variables).to.have.length(2);  // [arguments, b]
             expect(scope.references).to.have.length(2);  // [b, a]
 
             const reference = scope.references[1];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("a");
             expect(reference.resolved).to.be.null;
@@ -187,21 +208,24 @@ describe("References:", function() {
         });
     });
 
-    describe("When there is a `function` declaration on global,", function() {
-        it("the reference on global should NOT be resolved.", function() {
+    describe("When there is a `function` declaration on global,", () => {
+        it("the reference on global should NOT be resolved.", () => {
             const ast = espree(`
                 function a() {}
                 a();
             `);
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(2);  // [global, a]
 
             const scope = scopeManager.scopes[0];
+
             expect(scope.variables).to.have.length(1);
             expect(scope.references).to.have.length(1);
 
             const reference = scope.references[0];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("a");
             expect(reference.resolved).to.be.null;
@@ -210,7 +234,7 @@ describe("References:", function() {
             expect(reference.isRead()).to.be.true;
         });
 
-        it("the reference in functions should NOT be resolved.", function() {
+        it("the reference in functions should NOT be resolved.", () => {
             const ast = espree(`
                 function a() {}
                 function foo() {
@@ -218,14 +242,17 @@ describe("References:", function() {
                 }
             `);
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(3);  // [global, a, foo]
 
             const scope = scopeManager.scopes[2];
+
             expect(scope.variables).to.have.length(2);  // [arguments, b]
             expect(scope.references).to.have.length(2);  // [b, a]
 
             const reference = scope.references[1];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("a");
             expect(reference.resolved).to.be.null;
@@ -235,21 +262,24 @@ describe("References:", function() {
         });
     });
 
-    describe("When there is a `class` declaration on global,", function() {
-        it("the reference on global should be resolved.", function() {
+    describe("When there is a `class` declaration on global,", () => {
+        it("the reference on global should be resolved.", () => {
             const ast = espree(`
                 class A {}
                 let b = new A();
             `);
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(2);  // [global, A]
 
             const scope = scopeManager.scopes[0];
+
             expect(scope.variables).to.have.length(2);  // [A, b]
             expect(scope.references).to.have.length(2);  // [b, A]
 
             const reference = scope.references[1];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("A");
             expect(reference.resolved).to.equal(scope.variables[0]);
@@ -258,7 +288,7 @@ describe("References:", function() {
             expect(reference.isRead()).to.be.true;
         });
 
-        it("the reference in functions should be resolved.", function() {
+        it("the reference in functions should be resolved.", () => {
             const ast = espree(`
                 class A {}
                 function foo() {
@@ -266,14 +296,17 @@ describe("References:", function() {
                 }
             `);
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(3);  // [global, A, foo]
 
             const scope = scopeManager.scopes[2];
+
             expect(scope.variables).to.have.length(2);  // [arguments, b]
             expect(scope.references).to.have.length(2);  // [b, A]
 
             const reference = scope.references[1];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("A");
             expect(reference.resolved).to.equal(scopeManager.scopes[0].variables[0]);
@@ -283,22 +316,25 @@ describe("References:", function() {
         });
     });
 
-    describe("When there is a `let` declaration in functions,", function() {
-        it("the reference on the function should be resolved.", function() {
+    describe("When there is a `let` declaration in functions,", () => {
+        it("the reference on the function should be resolved.", () => {
             const ast = espree(`
                 function foo() {
                     let a = 0;
                 }
             `);
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
 
             const scope = scopeManager.scopes[1];
+
             expect(scope.variables).to.have.length(2);  // [arguments, a]
             expect(scope.references).to.have.length(1);
 
             const reference = scope.references[0];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("a");
             expect(reference.resolved).to.equal(scope.variables[1]);
@@ -307,7 +343,7 @@ describe("References:", function() {
             expect(reference.isRead()).to.be.false;
         });
 
-        it("the reference in nested functions should be resolved.", function() {
+        it("the reference in nested functions should be resolved.", () => {
             const ast = espree(`
                 function foo() {
                     let a = 0;
@@ -317,14 +353,17 @@ describe("References:", function() {
                 }
             `);
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(3);  // [global, foo, bar]
 
             const scope = scopeManager.scopes[2];
+
             expect(scope.variables).to.have.length(2);  // [arguments, b]
             expect(scope.references).to.have.length(2);  // [b, a]
 
             const reference = scope.references[1];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("a");
             expect(reference.resolved).to.equal(scopeManager.scopes[1].variables[1]);
@@ -334,22 +373,25 @@ describe("References:", function() {
         });
     });
 
-    describe("When there is a `var` declaration in functions,", function() {
-        it("the reference on the function should be resolved.", function() {
+    describe("When there is a `var` declaration in functions,", () => {
+        it("the reference on the function should be resolved.", () => {
             const ast = espree(`
                 function foo() {
                     var a = 0;
                 }
             `);
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
 
             const scope = scopeManager.scopes[1];
+
             expect(scope.variables).to.have.length(2);  // [arguments, a]
             expect(scope.references).to.have.length(1);
 
             const reference = scope.references[0];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("a");
             expect(reference.resolved).to.equal(scope.variables[1]);
@@ -358,7 +400,7 @@ describe("References:", function() {
             expect(reference.isRead()).to.be.false;
         });
 
-        it("the reference in nested functions should be resolved.", function() {
+        it("the reference in nested functions should be resolved.", () => {
             const ast = espree(`
                 function foo() {
                     var a = 0;
@@ -368,14 +410,17 @@ describe("References:", function() {
                 }
             `);
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(3);  // [global, foo, bar]
 
             const scope = scopeManager.scopes[2];
+
             expect(scope.variables).to.have.length(2);  // [arguments, b]
             expect(scope.references).to.have.length(2);  // [b, a]
 
             const reference = scope.references[1];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("a");
             expect(reference.resolved).to.equal(scopeManager.scopes[1].variables[1]);
@@ -385,18 +430,21 @@ describe("References:", function() {
         });
     });
 
-    describe("When there is a `let` declaration with destructuring assignment", function() {
-        it("\"let [a] = [1];\", the reference should be resolved.", function() {
+    describe("When there is a `let` declaration with destructuring assignment", () => {
+        it("\"let [a] = [1];\", the reference should be resolved.", () => {
             const ast = espree("let [a] = [1];");
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(1);
 
             const scope = scopeManager.scopes[0];
+
             expect(scope.variables).to.have.length(1);
             expect(scope.references).to.have.length(1);
 
             const reference = scope.references[0];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("a");
             expect(reference.resolved).to.equal(scope.variables[0]);
@@ -405,17 +453,20 @@ describe("References:", function() {
             expect(reference.isRead()).to.be.false;
         });
 
-        it("\"let {a} = {a: 1};\", the reference should be resolved.", function() {
+        it("\"let {a} = {a: 1};\", the reference should be resolved.", () => {
             const ast = espree("let {a} = {a: 1};");
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(1);
 
             const scope = scopeManager.scopes[0];
+
             expect(scope.variables).to.have.length(1);
             expect(scope.references).to.have.length(1);
 
             const reference = scope.references[0];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("a");
             expect(reference.resolved).to.equal(scope.variables[0]);
@@ -424,17 +475,20 @@ describe("References:", function() {
             expect(reference.isRead()).to.be.false;
         });
 
-        it("\"let {a: {a}} = {a: {a: 1}};\", the reference should be resolved.", function() {
+        it("\"let {a: {a}} = {a: {a: 1}};\", the reference should be resolved.", () => {
             const ast = espree("let {a: {a}} = {a: {a: 1}};");
 
-            const scopeManager = analyze(ast, {ecmaVersion: 6});
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
             expect(scopeManager.scopes).to.have.length(1);
 
             const scope = scopeManager.scopes[0];
+
             expect(scope.variables).to.have.length(1);
             expect(scope.references).to.have.length(1);
 
             const reference = scope.references[0];
+
             expect(reference.from).to.equal(scope);
             expect(reference.identifier.name).to.equal("a");
             expect(reference.resolved).to.equal(scope.variables[0]);
@@ -444,7 +498,7 @@ describe("References:", function() {
         });
     });
 
-    describe("Reference.init should be a boolean value of whether it is one to initialize or not.", function() {
+    describe("Reference.init should be a boolean value of whether it is one to initialize or not.", () => {
         const trueCodes = [
             "var a = 0;",
             "let a = 0;",
@@ -480,13 +534,15 @@ describe("References:", function() {
         ];
 
         trueCodes.forEach(code =>
-            it(`"${code}", all references should be true.`, function() {
+            it(`"${code}", all references should be true.`, () => {
                 const ast = espree(code);
 
-                const scopeManager = analyze(ast, {ecmaVersion: 6});
+                const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
                 expect(scopeManager.scopes).to.be.length.of.at.least(1);
 
                 const scope = scopeManager.scopes[scopeManager.scopes.length - 1];
+
                 expect(scope.variables).to.have.length.of.at.least(1);
                 expect(scope.references).to.have.length.of.at.least(1);
 
@@ -511,14 +567,17 @@ describe("References:", function() {
             "let a; for ({a} in []);",
             "let a; for ({a = 0} in []);"
         ];
+
         falseCodes.forEach(code =>
-            it(`"${code}", all references should be false.`, function() {
+            it(`"${code}", all references should be false.`, () => {
                 const ast = espree(code);
 
-                const scopeManager = analyze(ast, {ecmaVersion: 6});
+                const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
                 expect(scopeManager.scopes).to.be.length.of.at.least(1);
 
                 const scope = scopeManager.scopes[scopeManager.scopes.length - 1];
+
                 expect(scope.variables).to.have.length(1);
                 expect(scope.references).to.have.length.of.at.least(1);
 
@@ -547,17 +606,20 @@ describe("References:", function() {
             "let a,b; b = a.foo;"
         ];
         falseCodes.forEach(code =>
-            it(`"${code}", readonly references of "a" should be undefined.`, function() {
+            it(`"${code}", readonly references of "a" should be undefined.`, () => {
                 const ast = espree(code);
 
-                const scopeManager = analyze(ast, {ecmaVersion: 6});
+                const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
                 expect(scopeManager.scopes).to.be.length.of.at.least(1);
 
                 const scope = scopeManager.scopes[0];
+
                 expect(scope.variables).to.have.length.of.at.least(1);
                 expect(scope.variables[0].name).to.equal("a");
 
                 const references = scope.variables[0].references;
+
                 expect(references).to.have.length.of.at.least(1);
 
                 references.forEach(reference => {

--- a/tests/typescript.js
+++ b/tests/typescript.js
@@ -34,6 +34,7 @@ describe("typescript", () => {
             expect(scopeManager.scopes).to.have.length(4);
 
             const globalScope = scopeManager.scopes[0];
+
             expect(globalScope.type).to.be.equal("global");
             expect(globalScope.variables).to.have.length(1);
             expect(globalScope.references).to.have.length(0);
@@ -41,6 +42,7 @@ describe("typescript", () => {
 
             // Function scopes
             let scope = scopeManager.scopes[1];
+
             expect(scope.type).to.be.equal("function");
             expect(scope.variables).to.have.length(2);
             expect(scope.variables[0].name).to.be.equal("arguments");

--- a/tests/with-scope.js
+++ b/tests/with-scope.js
@@ -28,8 +28,8 @@ const expect = require("chai").expect;
 const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
-describe("with", function() {
-    it("creates scope", function() {
+describe("with", () => {
+    it("creates scope", () => {
         const ast = espree(`
             (function () {
                 with (obj) {
@@ -39,13 +39,16 @@ describe("with", function() {
         `, "script");
 
         const scopeManager = analyze(ast);
+
         expect(scopeManager.scopes).to.have.length(3);
         const globalScope = scopeManager.scopes[0];
+
         expect(globalScope.type).to.be.equal("global");
         expect(globalScope.variables).to.have.length(0);
         expect(globalScope.references).to.have.length(0);
 
         let scope = scopeManager.scopes[1];
+
         expect(scope.type).to.be.equal("function");
         expect(scope.variables).to.have.length(1);
         expect(scope.variables[0].name).to.be.equal("arguments");


### PR DESCRIPTION
This upgrades eslint-config-eslint to v4.0.0, and fixes all linting errors. Most of the errors were fixed by ESLint's autofixer.