### PR TITLE
Chore: Add files section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
     "alpharelease": "eslint-prerelease alpha",
     "betarelease": "eslint-prerelease beta"
   },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "lib"
+  ],
   "dependencies": {
     "esrecurse": "^4.1.0",
     "estraverse": "^4.1.1"


### PR DESCRIPTION
Package.json was missing `files` section, which prevents the release.