### PR TITLE
Scope Type Annotations

### DIFF
--- a/lib/referencer.js
+++ b/lib/referencer.js
@@ -185,6 +185,9 @@ class Referencer extends esrecurse.Visitor {
             node,
             options.processRightHandNodes ? this : null,
             callback);
+        if (node.typeAnnotation) {
+            this.visit(node.typeAnnotation);
+        }
     }
 
     visitFunction(node) {
@@ -270,6 +273,10 @@ class Referencer extends esrecurse.Visitor {
             } else {
                 this.visit(node.body);
             }
+        }
+
+        if (node.returnType) {
+            this.visit(node.returnType);
         }
 
         this.close(node);
@@ -630,6 +637,15 @@ class Referencer extends esrecurse.Visitor {
     MetaProperty() { // eslint-disable-line class-methods-use-this
 
         // do nothing.
+    }
+
+    TypeAnnotation(node) {
+        const typeName = node.typeAnnotation.typeName;
+
+        if (typeName) {
+            typeName.parent = node.typeAnnotation;
+        }
+        this.visit(typeName);
     }
 }
 

--- a/tests/typescript.js
+++ b/tests/typescript.js
@@ -66,4 +66,107 @@ describe("typescript", () => {
 
         });
     });
+    describe("Type Annotations", () => {
+        it("should scope varaible declartion type annotations", () => {
+            const ast = parse(`
+                var foo: TypeFoo;
+            `);
+
+            const scopeManager = analyze(ast);
+
+            expect(scopeManager.scopes).to.have.length(1);
+
+            const globalScope = scopeManager.scopes[0];
+
+            expect(globalScope.type).to.be.equal("global");
+            expect(globalScope.variables).to.have.length(1);
+            expect(globalScope.variables[0].name).to.equal("foo");
+            expect(globalScope.references).to.have.length(1);
+            expect(globalScope.references[0].identifier.name).to.equal("TypeFoo");
+        });
+        it("should scope function declaration type annotations", () => {
+            const ast = parse(`
+                function bar(): TypeBar {};
+            `);
+
+            const scopeManager = analyze(ast);
+
+            expect(scopeManager.scopes).to.have.length(2);
+
+            const globalScope = scopeManager.scopes[0];
+
+            expect(globalScope.type).to.be.equal("global");
+            expect(globalScope.variables).to.have.length(1);
+            expect(globalScope.variables[0].name).to.equal("bar");
+
+            // Function scopes
+            const scope = scopeManager.scopes[1];
+
+            expect(scope.references).to.have.length(1);
+            expect(scope.references[0].identifier.name).to.equal("TypeBar");
+        });
+        it("should scope function expression type annotations", () => {
+            const ast = parse(`
+                const bar = function (): TypeBar {};
+            `);
+
+            const scopeManager = analyze(ast);
+
+            expect(scopeManager.scopes).to.have.length(2);
+
+            const globalScope = scopeManager.scopes[0];
+
+            expect(globalScope.type).to.be.equal("global");
+            expect(globalScope.variables).to.have.length(1);
+            expect(globalScope.variables[0].name).to.equal("bar");
+
+            // Function scopes
+            const scope = scopeManager.scopes[1];
+
+            expect(scope.references).to.have.length(1);
+            expect(scope.references[0].identifier.name).to.equal("TypeBar");
+        });
+        it("should scope arrow function expression type annotations", () => {
+            const ast = parse(`
+                var baz = (): TypeBaz => {};
+            `);
+
+            const scopeManager = analyze(ast);
+
+            expect(scopeManager.scopes).to.have.length(2);
+
+            const globalScope = scopeManager.scopes[0];
+
+            expect(globalScope.type).to.be.equal("global");
+            expect(globalScope.variables).to.have.length(1);
+            expect(globalScope.variables[0].name).to.equal("baz");
+
+            // Function scopes
+            const scope = scopeManager.scopes[1];
+
+            expect(scope.references).to.have.length(1);
+            expect(scope.references[0].identifier.name).to.equal("TypeBaz");
+        });
+        it("should scope class method declaration type annotations", () => {
+            const ast = parse(`
+                class A { foobar(): TypeFooBar {} }
+            `);
+
+            const scopeManager = analyze(ast);
+
+            expect(scopeManager.scopes).to.have.length(3);
+
+            const globalScope = scopeManager.scopes[0];
+
+            expect(globalScope.type).to.be.equal("global");
+            expect(globalScope.variables).to.have.length(1);
+            expect(globalScope.variables[0].name).to.equal("A");
+
+            // Method scope
+            const scope = scopeManager.scopes[2];
+
+            expect(scope.references).to.have.length(1);
+            expect(scope.references[0].identifier.name).to.equal("TypeFooBar");
+        });
+    });
 });

--- a/tests/util/espree.js
+++ b/tests/util/espree.js
@@ -23,14 +23,15 @@
 */
 "use strict";
 
-var espree = require("espree");
+const espree = require("espree");
 
 module.exports = function(code, sourceType) {
     sourceType = sourceType || "module";
 
     return espree.parse(code, {
+
         // enable es6 features.
-        sourceType: sourceType
+        sourceType
     });
 };
 


### PR DESCRIPTION
This commit allows for type annotations in variable declarations and function/method expressions and  declarations to be scoped as references.

It allows for the eslint rule no-unused-vars to work correctly with types.

This is tailored to TypeScript since the estree type annotation node does not define how type annotations should look, just where they are defined.
https://github.com/estree/estree/blob/master/extensions/type-annotations.md

Typescript defines them like so:
```
 "typeAnnotation": {
        "type": "TypeAnnotation",
        "loc": {
            "start": {
                "line": 3,
                "column": 11
            },
            "end": {
                "line": 3,
                "column": 14
            }
        },
        "range": [
            37,
            40
        ],
        "typeAnnotation": {
            "type": "TSTypeReference",
            "range": [
                37,
                40
            ],
            "loc": {
                "start": {
                    "line": 3,
                    "column": 11
                },
                "end": {
                    "line": 3,
                    "column": 14
                }
            },
            "typeName": {
                "type": "Identifier",
                "range": [
                    37,
                    40
                ],
                "loc": {
                    "start": {
                        "line": 3,
                        "column": 11
                    },
                    "end": {
                        "line": 3,
                        "column": 14
                    }
                },
                "name": "Foo"
            }
        }
    }
},
```

Babel and Flow type use the property id to define the identifier for the type annotation not typeName. Maybe we should align typescript-eslint-parser with that convention.