### PR TITLE
Scope decorators

### DIFF
--- a/lib/referencer.js
+++ b/lib/referencer.js
@@ -241,7 +241,12 @@ class Referencer extends esrecurse.Visitor {
 
         // Process parameter declarations.
         for (i = 0, iz = node.params.length; i < iz; ++i) {
+            const paramNode = node.params[i];
+
             this.visitPattern(node.params[i], { processRightHandNodes: true }, visitPatternCallback);
+            if (paramNode.decorators) {
+                this.visitDecorators(paramNode.decorators, paramNode);
+            }
         }
 
         // if there's a rest argument, add that
@@ -275,6 +280,22 @@ class Referencer extends esrecurse.Visitor {
         this.close(node);
     }
 
+    visitDecorators(decorators, parent) {
+        for (let i = 0; i < decorators.length; i++) {
+            const decorator = decorators[i];
+
+            if (decorator.type === Syntax.CallExpression) {
+                decorator.callee.parent = decorator;
+            } else if (decorator.type === Syntax.Identifier) {
+                decorator.parent = parent;
+            } else {
+                throw new Error("Unexpected decorator type");
+            }
+
+            this.visit(decorator);
+        }
+    }
+
     visitClass(node) {
         if (node.type === Syntax.ClassDeclaration) {
             this.currentScope().__define(node.id,
@@ -302,6 +323,9 @@ class Referencer extends esrecurse.Visitor {
                     ));
         }
         this.visit(node.body);
+        if (node.decorators) {
+            this.visitDecorators(node.decorators, node);
+        }
 
         this.close(node);
     }
@@ -321,6 +345,10 @@ class Referencer extends esrecurse.Visitor {
         this.visit(node.value);
         if (isMethodDefinition) {
             this.popInnerMethodDefinition(previous);
+        }
+
+        if (node.decorators) {
+            this.visitDecorators(node.decorators, node);
         }
     }
 

--- a/tests/get-declared-variables.js
+++ b/tests/get-declared-variables.js
@@ -28,6 +28,7 @@ const espree = require("./util/espree");
 const analyze = require("..").analyze;
 
 describe("ScopeManager.prototype.getDeclaredVariables", () => {
+
     /* eslint-disable require-jsdoc */
     function verify(ast, type, expectedNamesList) {
         const scopeManager = analyze(ast, {

--- a/tests/typescript.js
+++ b/tests/typescript.js
@@ -66,4 +66,281 @@ describe("typescript", () => {
 
         });
     });
+
+    describe("Decorators", () => {
+        it("should create class decorator reference", () => {
+            const ast = parse(`
+                @Foo
+                class Bar { }
+            `);
+
+            const scopeManager = analyze(ast);
+
+            expect(scopeManager.scopes).to.have.length(2);
+
+            const globalScope = scopeManager.scopes[0];
+
+            expect(globalScope.type).to.be.equal("global");
+            expect(globalScope.variables).to.have.length(1);
+            expect(globalScope.references).to.have.length(0);
+            expect(globalScope.isArgumentsMaterialized()).to.be.true;
+
+            // Class scope
+            const scope = scopeManager.scopes[1];
+
+            expect(scope.type).to.be.equal("class");
+            expect(scope.block.type).to.be.equal("ClassDeclaration");
+            expect(scope.variables).to.have.length(1);
+            expect(scope.variables[0].name).to.be.equal("Bar");
+            expect(scope.references).to.have.length(1);
+            expect(scope.references[0].identifier.name).to.be.equal("Foo");
+        });
+
+        it("should create class decorator factory reference", () => {
+            const ast = parse(`
+                @Foo("Hello", world)
+                class Bar { }
+            `);
+
+            const scopeManager = analyze(ast);
+
+            expect(scopeManager.scopes).to.have.length(2);
+
+            const globalScope = scopeManager.scopes[0];
+
+            expect(globalScope.type).to.be.equal("global");
+            expect(globalScope.variables).to.have.length(1);
+            expect(globalScope.references).to.have.length(0);
+            expect(globalScope.isArgumentsMaterialized()).to.be.true;
+
+            // Class scope
+            const scope = scopeManager.scopes[1];
+
+            expect(scope.type).to.be.equal("class");
+            expect(scope.block.type).to.be.equal("ClassDeclaration");
+            expect(scope.variables).to.have.length(1);
+            expect(scope.variables[0].name).to.be.equal("Bar");
+            expect(scope.references).to.have.length(2);
+            expect(scope.references[0].identifier.name).to.be.equal("Foo");
+            expect(scope.references[1].identifier.name).to.be.equal("world");
+        });
+
+        it("should create class property decorator reference", () => {
+            const ast = parse(`
+                class Bar { 
+                    @Foo
+                    baz 
+                }
+            `);
+
+            const scopeManager = analyze(ast);
+
+            expect(scopeManager.scopes).to.have.length(2);
+
+            const globalScope = scopeManager.scopes[0];
+
+            expect(globalScope.type).to.be.equal("global");
+            expect(globalScope.variables).to.have.length(1);
+            expect(globalScope.references).to.have.length(0);
+            expect(globalScope.isArgumentsMaterialized()).to.be.true;
+
+            // Class scope
+            const scope = scopeManager.scopes[1];
+
+            expect(scope.type).to.be.equal("class");
+            expect(scope.block.type).to.be.equal("ClassDeclaration");
+            expect(scope.variables).to.have.length(1);
+            expect(scope.variables[0].name).to.be.equal("Bar");
+            expect(scope.references).to.have.length(2);
+            expect(scope.references[0].identifier.name).to.be.equal("baz");
+            expect(scope.references[1].identifier.name).to.be.equal("Foo");
+        });
+
+        it("should create class property decorator reference", () => {
+            const ast = parse(`
+                class Bar { 
+                    @Foo(zzz)
+                    baz 
+                }
+            `);
+
+            const scopeManager = analyze(ast);
+
+            expect(scopeManager.scopes).to.have.length(2);
+
+            const globalScope = scopeManager.scopes[0];
+
+            expect(globalScope.type).to.be.equal("global");
+            expect(globalScope.variables).to.have.length(1);
+            expect(globalScope.references).to.have.length(0);
+            expect(globalScope.isArgumentsMaterialized()).to.be.true;
+
+            // Class scope
+            const scope = scopeManager.scopes[1];
+
+            expect(scope.type).to.be.equal("class");
+            expect(scope.block.type).to.be.equal("ClassDeclaration");
+            expect(scope.variables).to.have.length(1);
+            expect(scope.variables[0].name).to.be.equal("Bar");
+            expect(scope.references).to.have.length(3);
+            expect(scope.references[0].identifier.name).to.be.equal("baz");
+            expect(scope.references[1].identifier.name).to.be.equal("Foo");
+            expect(scope.references[2].identifier.name).to.be.equal("zzz");
+        });
+
+        it("should create class method decorator reference", () => {
+            const ast = parse(`
+                class Bar { 
+                    @Foo
+                    baz() { } 
+                }
+            `);
+
+            const scopeManager = analyze(ast);
+
+            expect(scopeManager.scopes).to.have.length(3);
+
+            const globalScope = scopeManager.scopes[0];
+
+            expect(globalScope.type).to.be.equal("global");
+            expect(globalScope.variables).to.have.length(1);
+            expect(globalScope.references).to.have.length(0);
+            expect(globalScope.isArgumentsMaterialized()).to.be.true;
+
+            // Class scope
+            let scope = scopeManager.scopes[1];
+
+            expect(scope.type).to.be.equal("class");
+            expect(scope.block.type).to.be.equal("ClassDeclaration");
+            expect(scope.variables).to.have.length(1);
+            expect(scope.variables[0].name).to.be.equal("Bar");
+            expect(scope.references).to.have.length(1);
+            expect(scope.references[0].identifier.name).to.be.equal("Foo");
+
+            // Method scope
+            scope = scopeManager.scopes[2];
+            expect(scope.type).to.be.equal("function");
+            expect(scope.block.type).to.be.equal("FunctionExpression");
+            expect(scope.variables).to.have.length(1);
+            expect(scope.variables[0].name).to.be.equal("arguments");
+            expect(scope.references).to.have.length(0);
+        });
+
+        it("should create class method decorator factory reference", () => {
+            const ast = parse(`
+                class Bar { 
+                    @Foo(yyy)
+                    baz() { } 
+                }
+            `);
+
+            const scopeManager = analyze(ast);
+
+            expect(scopeManager.scopes).to.have.length(3);
+
+            const globalScope = scopeManager.scopes[0];
+
+            expect(globalScope.type).to.be.equal("global");
+            expect(globalScope.variables).to.have.length(1);
+            expect(globalScope.references).to.have.length(0);
+            expect(globalScope.isArgumentsMaterialized()).to.be.true;
+
+            // Class scope
+            let scope = scopeManager.scopes[1];
+
+            expect(scope.type).to.be.equal("class");
+            expect(scope.block.type).to.be.equal("ClassDeclaration");
+            expect(scope.variables).to.have.length(1);
+            expect(scope.variables[0].name).to.be.equal("Bar");
+            expect(scope.references).to.have.length(2);
+            expect(scope.references[0].identifier.name).to.be.equal("Foo");
+            expect(scope.references[1].identifier.name).to.be.equal("yyy");
+
+            // Method scope
+            scope = scopeManager.scopes[2];
+            expect(scope.type).to.be.equal("function");
+            expect(scope.block.type).to.be.equal("FunctionExpression");
+            expect(scope.variables).to.have.length(1);
+            expect(scope.variables[0].name).to.be.equal("arguments");
+            expect(scope.references).to.have.length(0);
+        });
+
+        it("should create class accessor method decorator reference", () => {
+            const ast = parse(`
+                class Bar { 
+                    @Foo
+                    get baz() { } 
+                }
+            `);
+
+            const scopeManager = analyze(ast);
+
+            expect(scopeManager.scopes).to.have.length(3);
+
+            const globalScope = scopeManager.scopes[0];
+
+            expect(globalScope.type).to.be.equal("global");
+            expect(globalScope.variables).to.have.length(1);
+            expect(globalScope.references).to.have.length(0);
+            expect(globalScope.isArgumentsMaterialized()).to.be.true;
+
+            // Class scope
+            let scope = scopeManager.scopes[1];
+
+            expect(scope.type).to.be.equal("class");
+            expect(scope.block.type).to.be.equal("ClassDeclaration");
+            expect(scope.variables).to.have.length(1);
+            expect(scope.variables[0].name).to.be.equal("Bar");
+            expect(scope.references).to.have.length(1);
+            expect(scope.references[0].identifier.name).to.be.equal("Foo");
+
+            // Method scope
+            scope = scopeManager.scopes[2];
+            expect(scope.type).to.be.equal("function");
+            expect(scope.block.type).to.be.equal("FunctionExpression");
+            expect(scope.variables).to.have.length(1);
+            expect(scope.variables[0].name).to.be.equal("arguments");
+            expect(scope.references).to.have.length(0);
+        });
+
+        it("should create class method decorator factory reference", () => {
+            const ast = parse(`
+                class Bar { 
+                    @Foo(yyy)
+                    get baz() { } 
+                }
+            `);
+
+            const scopeManager = analyze(ast);
+
+            expect(scopeManager.scopes).to.have.length(3);
+
+            const globalScope = scopeManager.scopes[0];
+
+            expect(globalScope.type).to.be.equal("global");
+            expect(globalScope.variables).to.have.length(1);
+            expect(globalScope.references).to.have.length(0);
+            expect(globalScope.isArgumentsMaterialized()).to.be.true;
+
+            // Class scope
+            let scope = scopeManager.scopes[1];
+
+            expect(scope.type).to.be.equal("class");
+            expect(scope.block.type).to.be.equal("ClassDeclaration");
+            expect(scope.variables).to.have.length(1);
+            expect(scope.variables[0].name).to.be.equal("Bar");
+            expect(scope.references).to.have.length(2);
+            expect(scope.references[0].identifier.name).to.be.equal("Foo");
+            expect(scope.references[1].identifier.name).to.be.equal("yyy");
+
+            // Method scope
+            scope = scopeManager.scopes[2];
+            expect(scope.type).to.be.equal("function");
+            expect(scope.block.type).to.be.equal("FunctionExpression");
+            expect(scope.variables).to.have.length(1);
+            expect(scope.variables[0].name).to.be.equal("arguments");
+            expect(scope.references).to.have.length(0);
+        });
+
+    });
 });

--- a/tests/util/espree.js
+++ b/tests/util/espree.js
@@ -23,14 +23,15 @@
 */
 "use strict";
 
-var espree = require("espree");
+const espree = require("espree");
 
 module.exports = function(code, sourceType) {
     sourceType = sourceType || "module";
 
     return espree.parse(code, {
+
         // enable es6 features.
-        sourceType: sourceType
+        sourceType
     });
 };
 


### PR DESCRIPTION
This PR allows for decorators to be scoped and for rules such as no-unused-vars to work correctly.