### PR TITLE
Fix: restore previous Scope API export behavior

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ const ScopeManager = require("./scope-manager");
 const Referencer = require("./referencer");
 const Reference = require("./reference");
 const Variable = require("./variable");
-const Scope = require("./scope");
+const Scope = require("./scope").Scope;
 const version = require("../package.json").version;
 
 /**


### PR DESCRIPTION
This fixes a divergence between the exported API of `eslint-scope` and `escope`. Previously, with `escope`, the following code would return the Scope class:
```js
> require('escope').Scope
[Function: Scope]
```

However, with `eslint-scope` this returns an object that has a key `Scope` in it:
```js
> require('eslint-scope').Scope
{ Scope: [Function: Scope],
  GlobalScope: [Function: GlobalScope],
  ModuleScope: [Function: ModuleScope],
  FunctionExpressionNameScope: [Function: FunctionExpressionNameScope],
  CatchScope: [Function: CatchScope],
  WithScope: [Function: WithScope],
  TDZScope: [Function: TDZScope],
  BlockScope: [Function: BlockScope],
  SwitchScope: [Function: SwitchScope],
  FunctionScope: [Function: FunctionScope],
  ForScope: [Function: ForScope],
  ClassScope: [Function: ClassScope] }
```

This happened during the refactoring from ES6 module syntax to `module.exports`, because `Scope` was the default export of `lib/scope.js`. Here's the change: https://github.com/eslint/eslint-scope/commit/019441e57cfe34d6acfe299b7b98d4bb9b8f4c3f#diff-7147267f980ceb48bd26aa2b36b061f2L132