### PR TITLE
Fix: wrong resolution about default parameters

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -341,22 +341,32 @@ class Scope {
         return this.upper;
     }
 
+    // To override by function scopes.
+    // References in default parameters isn't resolved to variables which are in their function body.
+    __isValidResolution(ref, variable) { // eslint-disable-line class-methods-use-this, no-unused-vars
+        return true;
+    }
+
     __resolve(ref) {
         const name = ref.identifier.name;
 
-        if (this.set.has(name)) {
-            const variable = this.set.get(name);
-
-            variable.references.push(ref);
-            variable.stack = variable.stack && ref.from.variableScope === this.variableScope;
-            if (ref.tainted) {
-                variable.tainted = true;
-                this.taints.set(variable.name, true);
-            }
-            ref.resolved = variable;
-            return true;
+        if (!this.set.has(name)) {
+            return false;
         }
-        return false;
+        const variable = this.set.get(name);
+
+        if (!this.__isValidResolution(ref, variable)) {
+            return false;
+        }
+        variable.references.push(ref);
+        variable.stack = variable.stack && ref.from.variableScope === this.variableScope;
+        if (ref.tainted) {
+            variable.tainted = true;
+            this.taints.set(variable.name, true);
+        }
+        ref.resolved = variable;
+
+        return true;
     }
 
     __delegateToUpperScope(ref) {
@@ -689,6 +699,29 @@ class FunctionScope extends Scope {
                 null,
                 null);
         this.taints.set("arguments", true);
+    }
+
+    // References in default parameters isn't resolved to variables which are in their function body.
+    //     const x = 1
+    //     function f(a = x) { // This `x` is resolved to the `x` in the outer scope.
+    //         const x = 2
+    //         console.log(a)
+    //     }
+    __isValidResolution(ref, variable) {
+
+        // If `options.nodejsScope` is true, `this.block` becomes a Program node.
+        if (this.block.type === "Program") {
+            return true;
+        }
+
+        const bodyStart = this.block.body.range[0];
+
+        // It's invalid resolution in the following case:
+        return !(
+            variable.scope === this &&
+            ref.identifier.range[0] < bodyStart &&                 // the reference is in the parameter part.
+            variable.defs.every(d => d.name.range[0] >= bodyStart) // the variable is in the body.
+        );
     }
 }
 

--- a/tests/es6-default-parameters.js
+++ b/tests/es6-default-parameters.js
@@ -239,6 +239,136 @@ describe("ES6 default parameters:", () => {
             });
         }
     });
+
+    describe("a default parameter creates a readable reference for references in right. It's resolved to outer scope's even if there is the variable in the function body:", () => {
+        const patterns = {
+            FunctionDeclaration: `
+                let a;
+                function foo(b = a) { let a; }
+            `,
+            FunctionExpression: `
+                let a;
+                let foo = function(b = a) { let a; }
+            `,
+            ArrowExpression: `
+                let a;
+                let foo = (b = a) => { let a; };
+            `
+        };
+
+        for (const name in patterns) {
+            const code = patterns[name];
+
+            it(name, () => {
+                const numVars = name === "ArrowExpression" ? 2 : 3;
+                const ast = espree(code);
+
+                const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
+                expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
+
+                const scope = scopeManager.scopes[1];
+
+                expect(scope.variables).to.have.length(numVars);  // [arguments?, b, a]
+                expect(scope.references).to.have.length(2);  // [b, a]
+
+                const reference = scope.references[1];
+
+                expect(reference.from).to.equal(scope);
+                expect(reference.identifier.name).to.equal("a");
+                expect(reference.resolved).to.equal(scopeManager.scopes[0].variables[0]);
+                expect(reference.writeExpr).to.be.undefined;
+                expect(reference.isWrite()).to.be.false;
+                expect(reference.isRead()).to.be.true;
+            });
+        }
+    });
+
+    describe("a default parameter creates a readable reference for references in right. It's resolved to the parameter:", () => {
+        const patterns = {
+            FunctionDeclaration: `
+                let a;
+                function foo(b = a, a) { }
+            `,
+            FunctionExpression: `
+                let a;
+                let foo = function(b = a, a) { }
+            `,
+            ArrowExpression: `
+                let a;
+                let foo = (b = a, a) => { };
+            `
+        };
+
+        for (const name in patterns) {
+            const code = patterns[name];
+
+            it(name, () => {
+                const numVars = name === "ArrowExpression" ? 2 : 3;
+                const ast = espree(code);
+
+                const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
+                expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
+
+                const scope = scopeManager.scopes[1];
+
+                expect(scope.variables).to.have.length(numVars);  // [arguments?, b, a]
+                expect(scope.references).to.have.length(2);  // [b, a]
+
+                const reference = scope.references[1];
+
+                expect(reference.from).to.equal(scope);
+                expect(reference.identifier.name).to.equal("a");
+                expect(reference.resolved).to.equal(scope.variables[scope.variables.length - 1]);
+                expect(reference.writeExpr).to.be.undefined;
+                expect(reference.isWrite()).to.be.false;
+                expect(reference.isRead()).to.be.true;
+            });
+        }
+    });
+
+    describe("a default parameter creates a readable reference for references in right (nested scope). It's resolved to outer scope's even if there is the variable in the function body:", () => {
+        const patterns = {
+            FunctionDeclaration: `
+                let a;
+                function foo(b = function(){ a }) { let a; }
+            `,
+            FunctionExpression: `
+                let a;
+                let foo = function(b = function(){ a }) { let a; }
+            `,
+            ArrowExpression: `
+                let a;
+                let foo = (b = function(){ a }) => { let a; };
+            `
+        };
+
+        for (const name in patterns) {
+            const code = patterns[name];
+
+            it(name, () => {
+                const ast = espree(code);
+
+                const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
+                expect(scopeManager.scopes).to.have.length(3);  // [global, foo, anonymous function]
+
+                const scope = scopeManager.scopes[2];
+
+                expect(scope.references).to.have.length(1);  // [a]
+
+                const reference = scope.references[0];
+
+                expect(reference.from).to.equal(scope);
+                expect(reference.identifier.name).to.equal("a");
+                expect(reference.resolved).to.equal(scopeManager.scopes[0].variables[0]);
+                expect(reference.writeExpr).to.be.undefined;
+                expect(reference.isWrite()).to.be.false;
+                expect(reference.isRead()).to.be.true;
+            });
+        }
+    });
 });
 
 // vim: set sw=4 ts=4 et tw=80 :

--- a/tests/util/espree.js
+++ b/tests/util/espree.js
@@ -23,14 +23,14 @@
 */
 "use strict";
 
-var espree = require("espree");
+const espree = require("espree");
 
 module.exports = function(code, sourceType) {
     sourceType = sourceType || "module";
 
     return espree.parse(code, {
-        // enable es6 features.
-        sourceType: sourceType
+        range: true,
+        sourceType
     });
 };
 

--- a/tests/util/espree.js
+++ b/tests/util/espree.js
@@ -30,6 +30,7 @@ module.exports = function(code, sourceType) {
 
     return espree.parse(code, {
         range: true,
+        ecmaVersion: 7,
         sourceType
     });
 };


### PR DESCRIPTION
Fixes eslint/eslint#9335.

This PR fixes wrong resolutions about the references in default parameters. In the following case:

```js
let a // (A)
function f(x = a) { // This `a` should be resolved to (A), but was resovled to (B).
    let a // (B)
}
```

After this PR, the `a` in default parameters is resolved to (A) correctly.

----

This fixing is not ideal.

As the step 27.a of [9.2.12 FunctionDeclarationInstantiation( func, argumentsList )](https://www.ecma-international.org/ecma-262/8.0/#sec-functiondeclarationinstantiation) mentioned, it should make new scope for the function body if the parameters has any default value. However, I guessed that it's a huge breaking change which breaks many ESLint rules. So I kept scope structure and modified the resolution logic.