### PR TITLE
Breaking: remove TDZScope (refs eslint/eslint#10245)

### DIFF
--- a/lib/scope-manager.js
+++ b/lib/scope-manager.js
@@ -36,7 +36,6 @@ const ClassScope = Scope.ClassScope;
 const SwitchScope = Scope.SwitchScope;
 const FunctionScope = Scope.FunctionScope;
 const ForScope = Scope.ForScope;
-const TDZScope = Scope.TDZScope;
 const FunctionExpressionNameScope = Scope.FunctionExpressionNameScope;
 const BlockScope = Scope.BlockScope;
 
@@ -116,9 +115,6 @@ class ScopeManager {
          */
         function predicate(testScope) {
             if (testScope.type === "function" && testScope.functionExpressionScope) {
-                return false;
-            }
-            if (testScope.type === "TDZ") {
                 return false;
             }
             return true;
@@ -235,10 +231,6 @@ class ScopeManager {
 
     __nestModuleScope(node) {
         return this.__nestScope(new ModuleScope(this, this.__currentScope, node));
-    }
-
-    __nestTDZScope(node) {
-        return this.__nestScope(new TDZScope(this, this.__currentScope, node));
     }
 
     __nestFunctionExpressionNameScope(node) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -157,7 +157,7 @@ class Scope {
     constructor(scopeManager, type, upperScope, block, isMethodDefinition) {
 
         /**
-         * One of 'TDZ', 'module', 'block', 'switch', 'function', 'catch', 'with', 'function', 'class', 'global'.
+         * One of 'module', 'block', 'switch', 'function', 'catch', 'with', 'function', 'class', 'global'.
          * @member {String} Scope#type
          */
         this.type = type;
@@ -404,10 +404,8 @@ class Scope {
 
         if (def) {
             variable.defs.push(def);
-            if (def.type !== Variable.TDZ) {
-                this.__addDeclaredVariablesOfNode(variable, def.node);
-                this.__addDeclaredVariablesOfNode(variable, def.parent);
-            }
+            this.__addDeclaredVariablesOfNode(variable, def.node);
+            this.__addDeclaredVariablesOfNode(variable, def.parent);
         }
         if (node) {
             variable.identifiers.push(node);
@@ -631,12 +629,6 @@ class WithScope extends Scope {
     }
 }
 
-class TDZScope extends Scope {
-    constructor(scopeManager, upperScope, block) {
-        super(scopeManager, "TDZ", upperScope, block, false);
-    }
-}
-
 class BlockScope extends Scope {
     constructor(scopeManager, upperScope, block) {
         super(scopeManager, "block", upperScope, block, false);
@@ -744,7 +736,6 @@ module.exports = {
     FunctionExpressionNameScope,
     CatchScope,
     WithScope,
-    TDZScope,
     BlockScope,
     SwitchScope,
     FunctionScope,

--- a/lib/variable.js
+++ b/lib/variable.js
@@ -81,7 +81,6 @@ Variable.FunctionName = "FunctionName";
 Variable.ClassName = "ClassName";
 Variable.Variable = "Variable";
 Variable.ImportBinding = "ImportBinding";
-Variable.TDZ = "TDZ";
 Variable.ImplicitGlobalVariable = "ImplicitGlobalVariable";
 
 module.exports = Variable;

--- a/tests/es6-destructuring-assignments.js
+++ b/tests/es6-destructuring-assignments.js
@@ -81,7 +81,7 @@ describe("ES6 destructuring assignments", () => {
 
         const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-        expect(scopeManager.scopes).to.have.length(4);  // [global, function, TDZ, for]
+        expect(scopeManager.scopes).to.have.length(3);  // [global, function, for]
 
         let scope = scopeManager.scopes[0];
 
@@ -92,22 +92,12 @@ describe("ES6 destructuring assignments", () => {
         expect(scope.implicit.left[0].identifier.name).to.equal("array");
 
         scope = scopeManager.scopes[2];
-        expect(scope.type).to.equal("TDZ");
-        expect(scope.variables).to.have.length(3);
-        expect(scope.variables[0].name).to.equal("a");
-        expect(scope.variables[1].name).to.equal("b");
-        expect(scope.variables[2].name).to.equal("c");
-        expect(scope.references).to.have.length(1);
-        expect(scope.references[0].identifier.name).to.equal("array");
-        expect(scope.references[0].isWrite()).to.be.false;
-
-        scope = scopeManager.scopes[3];
         expect(scope.type).to.equal("for");
         expect(scope.variables).to.have.length(3);
         expect(scope.variables[0].name).to.equal("a");
         expect(scope.variables[1].name).to.equal("b");
         expect(scope.variables[2].name).to.equal("c");
-        expect(scope.references).to.have.length(3);
+        expect(scope.references).to.have.length(4);
         expect(scope.references[0].identifier.name).to.equal("a");
         expect(scope.references[0].isWrite()).to.be.true;
         expect(scope.references[0].partial).to.be.true;
@@ -120,6 +110,9 @@ describe("ES6 destructuring assignments", () => {
         expect(scope.references[2].isWrite()).to.be.true;
         expect(scope.references[2].partial).to.be.true;
         expect(scope.references[2].resolved).to.equal(scope.variables[2]);
+        expect(scope.references[3].identifier.name).to.equal("array");
+        expect(scope.references[3].isWrite()).to.be.false;
+        expect(scope.references[3].resolved).to.be.null;
     });
 
     it("Pattern with default values in var in ForInStatement", () => {
@@ -183,7 +176,7 @@ describe("ES6 destructuring assignments", () => {
 
         const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-        expect(scopeManager.scopes).to.have.length(4);  // [global, function, TDZ, for]
+        expect(scopeManager.scopes).to.have.length(3);  // [global, function, for]
 
         let scope = scopeManager.scopes[0];
 
@@ -191,28 +184,18 @@ describe("ES6 destructuring assignments", () => {
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
         expect(scope.implicit.left).to.have.length(2);
-        expect(scope.implicit.left[0].identifier.name).to.equal("array");
-        expect(scope.implicit.left[0].from.type).to.equal("TDZ");
-        expect(scope.implicit.left[1].identifier.name).to.equal("d");
+        expect(scope.implicit.left[0].identifier.name).to.equal("d");
+        expect(scope.implicit.left[0].from.type).to.equal("for");
+        expect(scope.implicit.left[1].identifier.name).to.equal("array");
         expect(scope.implicit.left[1].from.type).to.equal("for");
 
         scope = scopeManager.scopes[2];
-        expect(scope.type).to.equal("TDZ");
-        expect(scope.variables).to.have.length(3);
-        expect(scope.variables[0].name).to.equal("a");
-        expect(scope.variables[1].name).to.equal("b");
-        expect(scope.variables[2].name).to.equal("c");
-        expect(scope.references).to.have.length(1);
-        expect(scope.references[0].identifier.name).to.equal("array");
-        expect(scope.references[0].isWrite()).to.be.false;
-
-        scope = scopeManager.scopes[3];
         expect(scope.type).to.equal("for");
         expect(scope.variables).to.have.length(3);
         expect(scope.variables[0].name).to.equal("a");
         expect(scope.variables[1].name).to.equal("b");
         expect(scope.variables[2].name).to.equal("c");
-        expect(scope.references).to.have.length(5);
+        expect(scope.references).to.have.length(6);
         expect(scope.references[0].identifier.name).to.equal("c");
         expect(scope.references[0].isWrite()).to.be.true;
         expect(scope.references[0].writeExpr.name).to.equal("d");
@@ -235,6 +218,9 @@ describe("ES6 destructuring assignments", () => {
         expect(scope.references[4].writeExpr.name).to.equal("array");
         expect(scope.references[4].partial).to.be.true;
         expect(scope.references[4].resolved).to.equal(scope.variables[2]);
+        expect(scope.references[5].identifier.name).to.equal("array");
+        expect(scope.references[5].isWrite()).to.be.false;
+        expect(scope.references[5].resolved).to.be.null;
     });
 
     it("Pattern with nested default values in var in ForInStatement", () => {
@@ -313,7 +299,7 @@ describe("ES6 destructuring assignments", () => {
 
         const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-        expect(scopeManager.scopes).to.have.length(4);  // [global, function, TDZ, for]
+        expect(scopeManager.scopes).to.have.length(3);  // [global, function, for]
 
         let scope = scopeManager.scopes[0];
 
@@ -321,30 +307,20 @@ describe("ES6 destructuring assignments", () => {
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(0);
         expect(scope.implicit.left).to.have.length(3);
-        expect(scope.implicit.left[0].identifier.name).to.equal("array");
-        expect(scope.implicit.left[0].from.type).to.equal("TDZ");
-        expect(scope.implicit.left[1].identifier.name).to.equal("d");
+        expect(scope.implicit.left[0].identifier.name).to.equal("d");
+        expect(scope.implicit.left[0].from.type).to.equal("for");
+        expect(scope.implicit.left[1].identifier.name).to.equal("e");
         expect(scope.implicit.left[1].from.type).to.equal("for");
-        expect(scope.implicit.left[2].identifier.name).to.equal("e");
+        expect(scope.implicit.left[2].identifier.name).to.equal("array");
         expect(scope.implicit.left[2].from.type).to.equal("for");
 
         scope = scopeManager.scopes[2];
-        expect(scope.type).to.equal("TDZ");
-        expect(scope.variables).to.have.length(3);
-        expect(scope.variables[0].name).to.equal("a");
-        expect(scope.variables[1].name).to.equal("b");
-        expect(scope.variables[2].name).to.equal("c");
-        expect(scope.references).to.have.length(1);
-        expect(scope.references[0].identifier.name).to.equal("array");
-        expect(scope.references[0].isWrite()).to.be.false;
-
-        scope = scopeManager.scopes[3];
         expect(scope.type).to.equal("for");
         expect(scope.variables).to.have.length(3);
         expect(scope.variables[0].name).to.equal("a");
         expect(scope.variables[1].name).to.equal("b");
         expect(scope.variables[2].name).to.equal("c");
-        expect(scope.references).to.have.length(8);
+        expect(scope.references).to.have.length(9);
         expect(scope.references[0].identifier.name).to.equal("b");
         expect(scope.references[0].isWrite()).to.be.true;
         expect(scope.references[0].writeExpr.name).to.equal("e");
@@ -379,6 +355,9 @@ describe("ES6 destructuring assignments", () => {
         expect(scope.references[7].writeExpr.name).to.equal("array");
         expect(scope.references[7].partial).to.be.true;
         expect(scope.references[7].resolved).to.equal(scope.variables[2]);
+        expect(scope.references[8].identifier.name).to.equal("array");
+        expect(scope.references[8].isWrite()).to.be.false;
+        expect(scope.references[8].resolved).to.be.null;
     });
 
     it("Pattern with default values in var in ForInStatement (separate declarations)", () => {

--- a/tests/es6-iteration-scope.js
+++ b/tests/es6-iteration-scope.js
@@ -41,7 +41,7 @@ describe("ES6 iteration scope", () => {
 
         const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-        expect(scopeManager.scopes).to.have.length(5);
+        expect(scopeManager.scopes).to.have.length(4);
 
         let scope = scopeManager.scopes[0];
 
@@ -57,25 +57,18 @@ describe("ES6 iteration scope", () => {
         expect(scope.references[0].identifier.name).to.be.equal("i");
         expect(scope.references[0].resolved).to.be.equal(scope.variables[1]);
 
-        let iterScope = scope = scopeManager.scopes[2];
+        const iterScope = scope = scopeManager.scopes[2];
 
-        expect(scope.type).to.be.equal("TDZ");
-        expect(scope.variables).to.have.length(1);
-        expect(scope.variables[0].name).to.be.equal("i");
-        expect(scope.variables[0].defs[0].type).to.be.equal("TDZ");
-        expect(scope.references).to.have.length(1);
-        expect(scope.references[0].identifier.name).to.be.equal("i");
-        expect(scope.references[0].resolved).to.be.equal(scope.variables[0]);
-
-        iterScope = scope = scopeManager.scopes[3];
         expect(scope.type).to.be.equal("for");
         expect(scope.variables).to.have.length(1);
         expect(scope.variables[0].name).to.be.equal("i");
-        expect(scope.references).to.have.length(1);
+        expect(scope.references).to.have.length(2);
         expect(scope.references[0].identifier.name).to.be.equal("i");
         expect(scope.references[0].resolved).to.be.equal(scope.variables[0]);
+        expect(scope.references[1].identifier.name).to.be.equal("i");
+        expect(scope.references[1].resolved).to.be.equal(scope.variables[0]);
 
-        scope = scopeManager.scopes[4];
+        scope = scopeManager.scopes[3];
         expect(scope.type).to.be.equal("block");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(2);
@@ -97,7 +90,7 @@ describe("ES6 iteration scope", () => {
 
         const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-        expect(scopeManager.scopes).to.have.length(5);
+        expect(scopeManager.scopes).to.have.length(4);
 
         let scope = scopeManager.scopes[0];
 
@@ -113,35 +106,24 @@ describe("ES6 iteration scope", () => {
         expect(scope.references[0].identifier.name).to.be.equal("i");
         expect(scope.references[0].resolved).to.be.equal(scope.variables[1]);
 
-        let iterScope = scope = scopeManager.scopes[2];
+        const iterScope = scope = scopeManager.scopes[2];
 
-        expect(scope.type).to.be.equal("TDZ");
-        expect(scope.variables).to.have.length(3);
-        expect(scope.variables[0].name).to.be.equal("i");
-        expect(scope.variables[0].defs[0].type).to.be.equal("TDZ");
-        expect(scope.variables[1].name).to.be.equal("j");
-        expect(scope.variables[1].defs[0].type).to.be.equal("TDZ");
-        expect(scope.variables[2].name).to.be.equal("k");
-        expect(scope.variables[2].defs[0].type).to.be.equal("TDZ");
-        expect(scope.references).to.have.length(1);
-        expect(scope.references[0].identifier.name).to.be.equal("i");
-        expect(scope.references[0].resolved).to.be.equal(scope.variables[0]);
-
-        iterScope = scope = scopeManager.scopes[3];
         expect(scope.type).to.be.equal("for");
         expect(scope.variables).to.have.length(3);
         expect(scope.variables[0].name).to.be.equal("i");
         expect(scope.variables[1].name).to.be.equal("j");
         expect(scope.variables[2].name).to.be.equal("k");
-        expect(scope.references).to.have.length(3);
+        expect(scope.references).to.have.length(4);
         expect(scope.references[0].identifier.name).to.be.equal("i");
         expect(scope.references[0].resolved).to.be.equal(scope.variables[0]);
         expect(scope.references[1].identifier.name).to.be.equal("j");
         expect(scope.references[1].resolved).to.be.equal(scope.variables[1]);
         expect(scope.references[2].identifier.name).to.be.equal("k");
         expect(scope.references[2].resolved).to.be.equal(scope.variables[2]);
+        expect(scope.references[3].identifier.name).to.be.equal("i");
+        expect(scope.references[3].resolved).to.be.equal(scope.variables[0]);
 
-        scope = scopeManager.scopes[4];
+        scope = scopeManager.scopes[3];
         expect(scope.type).to.be.equal("block");
         expect(scope.variables).to.have.length(0);
         expect(scope.references).to.have.length(2);


### PR DESCRIPTION
Refs eslint/eslint#10245.

This PR removes `TDZScope` class.
`eslint-scope` package should not make TDZ scopes because this is static analyzer and Temporal Dead Zone is a timing matter.

As results:

- `for-in`/`for-of` statements no longer make TDZ scopes.
- The references in `ForInStatement#right` and `ForOfStatement#right` are in the correct place now.

I confirmed that `eslint` doesn't need any fix for this change (eslint/eslint#10270).