### PR TITLE
Upgrade: eslint-release@1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 *.iml
 /.vscode
 .sublimelinterrc
+.eslint-release-info.json

--- a/package.json
+++ b/package.json
@@ -15,12 +15,11 @@
   "scripts": {
     "test": "node Makefile.js test",
     "lint": "node Makefile.js lint",
-    "release": "eslint-release",
-    "ci-release": "eslint-ci-release",
-    "gh-release": "eslint-gh-release",
-    "alpharelease": "eslint-prerelease alpha",
-    "betarelease": "eslint-prerelease beta",
-    "rcrelease": "eslint-prerelease rc"
+    "generate-release": "eslint-generate-release",
+    "generate-alpharelease": "eslint-generate-prerelease alpha",
+    "generate-betarelease": "eslint-generate-prerelease beta",
+    "generate-rcrelease": "eslint-generate-prerelease rc",
+    "publish-release": "eslint-publish-release"
   },
   "files": [
     "LICENSE",
@@ -35,7 +34,7 @@
     "chai": "^3.4.1",
     "eslint": "^3.15.0",
     "eslint-config-eslint": "^4.0.0",
-    "eslint-release": "^0.11.1",
+    "eslint-release": "^1.0.0",
     "espree": "^3.1.1",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",


### PR DESCRIPTION
(refs https://github.com/eslint/eslint/issues/10631)

This updates `eslint-release` to allow the package to still be published from the Jenkins server now that we have 2FA enabled on the bot account.

Some changes are also needed on the Jenkins server -- I plan to make those changes after this is merged.