### PR TITLE
Chore: add supported Node.js versions to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: node_js
 node_js:
     - "4"
-    - "5"
     - "6"
-    - "7"
+    - "8"
+    - "9"
+    - "10"
+    - "11"
 sudo: false
 script: "npm test"


### PR DESCRIPTION
Wanted to add Node v11 to the list of versions in CI and noticed a few others were missing. Do we want to drop support for Node@<6 at some point?