### PR TITLE
Revert "Fix: Arrow function scope strictness (fixes #49) (#50)"

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -49,6 +49,11 @@ function isStrictScope(scope, block, isMethodDefinition, useDirective) {
         return true;
     }
 
+    // ArrowFunctionExpression's scope is always strict scope.
+    if (block.type === Syntax.ArrowFunctionExpression) {
+        return true;
+    }
+
     if (isMethodDefinition) {
         return true;
     }

--- a/tests/es6-arrow-function-expression.js
+++ b/tests/es6-arrow-function-expression.js
@@ -52,7 +52,7 @@ describe("ES6 arrow function expression", () => {
         scope = scopeManager.scopes[1];
         expect(scope.type).to.be.equal("function");
         expect(scope.block.type).to.be.equal("ArrowFunctionExpression");
-        expect(scope.isStrict).to.be.false;
+        expect(scope.isStrict).to.be.true;
         expect(scope.variables).to.have.length(2);
 
         // There's no "arguments"
@@ -77,7 +77,7 @@ describe("ES6 arrow function expression", () => {
         scope = scopeManager.scopes[1];
         expect(scope.type).to.be.equal("function");
         expect(scope.block.type).to.be.equal("ArrowFunctionExpression");
-        expect(scope.isStrict).to.be.false;
+        expect(scope.isStrict).to.be.true;
         expect(scope.variables).to.have.length(4);
 
         // There's no "arguments"
@@ -85,57 +85,6 @@ describe("ES6 arrow function expression", () => {
         expect(scope.variables[1].name).to.be.equal("b");
         expect(scope.variables[2].name).to.be.equal("c");
         expect(scope.variables[3].name).to.be.equal("d");
-    });
-
-    it("inherits upper scope strictness", () => {
-        const ast = espree(`
-            "use strict";
-            var arrow = () => {};
-        `);
-
-        const scopeManager = analyze(ast, { ecmaVersion: 6 });
-
-        expect(scopeManager.scopes).to.have.length(2);
-
-        let scope = scopeManager.scopes[0];
-
-        expect(scope.type).to.be.equal("global");
-        expect(scope.block.type).to.be.equal("Program");
-        expect(scope.isStrict).to.be.true;
-        expect(scope.variables).to.have.length(1);
-
-        scope = scopeManager.scopes[1];
-
-        expect(scope.type).to.be.equal("function");
-        expect(scope.block.type).to.be.equal("ArrowFunctionExpression");
-        expect(scope.isStrict).to.be.true;
-        expect(scope.variables).to.have.length(0);
-    });
-
-    it("is strict when a strictness directive is used", () => {
-        const ast = espree(`
-            var arrow = () => {
-                "use strict";
-            };
-        `);
-
-        const scopeManager = analyze(ast, { ecmaVersion: 6 });
-
-        expect(scopeManager.scopes).to.have.length(2);
-
-        let scope = scopeManager.scopes[0];
-
-        expect(scope.type).to.be.equal("global");
-        expect(scope.block.type).to.be.equal("Program");
-        expect(scope.isStrict).to.be.false;
-        expect(scope.variables).to.have.length(1);
-
-        scope = scopeManager.scopes[1];
-
-        expect(scope.type).to.be.equal("function");
-        expect(scope.block.type).to.be.equal("ArrowFunctionExpression");
-        expect(scope.isStrict).to.be.true;
-        expect(scope.variables).to.have.length(0);
     });
 });
 


### PR DESCRIPTION
This reverts commit 2533966faf317df5a3847fab937ba462c16808b8.

The change is causing ESLint to crash with a parsing error on the following code:

```js
console.log(this); z(x => console.log(x, this))
```

```
TypeError: Cannot read property 'length' of undefined
    at isStrictScope (/Users/tkatz/code/eslint/node_modules/eslint-scope/lib/scope.js:93:40)
    at new Scope (/Users/tkatz/code/eslint/node_modules/eslint-scope/lib/scope.js:254:25)
    at new FunctionScope (/Users/tkatz/code/eslint/node_modules/eslint-scope/lib/scope.js:641:9)
    at ScopeManager.__nestFunctionScope (/Users/tkatz/code/eslint/node_modules/eslint-scope/lib/scope-manager.js:209:33)
    at Referencer.visitFunction (/Users/tkatz/code/eslint/node_modules/eslint-scope/lib/referencer.js:200:27)
    at Referencer.ArrowFunctionExpression (/Users/tkatz/code/eslint/node_modules/eslint-scope/lib/referencer.js:567:14)
    at Referencer.Visitor.visit (/Users/tkatz/code/eslint/node_modules/esrecurse/esrecurse.js:104:34)
    at Referencer.Visitor.visitChildren (/Users/tkatz/code/eslint/node_modules/esrecurse/esrecurse.js:83:38)
    at Referencer.CallExpression (/Users/tkatz/code/eslint/node_modules/eslint-scope/lib/referencer.js:494:14)
    at Referencer.Visitor.visit (/Users/tkatz/code/eslint/node_modules/esrecurse/esrecurse.js:104:34)
```

Since this is currently affecting ESLint users, we're reverting the change for now until we figure out the root cause.