### PR TITLE
Fix: arrow function scope strictness (take 2)

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -49,11 +49,6 @@ function isStrictScope(scope, block, isMethodDefinition, useDirective) {
         return true;
     }
 
-    // ArrowFunctionExpression's scope is always strict scope.
-    if (block.type === Syntax.ArrowFunctionExpression) {
-        return true;
-    }
-
     if (isMethodDefinition) {
         return true;
     }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -62,6 +62,10 @@ function isStrictScope(scope, block, isMethodDefinition, useDirective) {
     }
 
     if (scope.type === "function") {
+        if (block.type === Syntax.ArrowFunctionExpression && block.body.type !== Syntax.BlockStatement) {
+            return false;
+        }
+
         if (block.type === Syntax.Program) {
             body = block;
         } else {
@@ -74,11 +78,6 @@ function isStrictScope(scope, block, isMethodDefinition, useDirective) {
     } else if (scope.type === "global") {
         body = block;
     } else {
-        return false;
-    }
-
-    // A function with non-block body, like `() => 1`
-    if (!body.body) {
         return false;
     }
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -77,6 +77,11 @@ function isStrictScope(scope, block, isMethodDefinition, useDirective) {
         return false;
     }
 
+    // A function with non-block body, like `() => 1`
+    if (!body.body) {
+        return false;
+    }
+
     // Search 'use strict' directive.
     if (useDirective) {
         for (let i = 0, iz = body.body.length; i < iz; ++i) {

--- a/tests/es6-arrow-function-expression.js
+++ b/tests/es6-arrow-function-expression.js
@@ -52,7 +52,7 @@ describe("ES6 arrow function expression", () => {
         scope = scopeManager.scopes[1];
         expect(scope.type).to.be.equal("function");
         expect(scope.block.type).to.be.equal("ArrowFunctionExpression");
-        expect(scope.isStrict).to.be.true;
+        expect(scope.isStrict).to.be.false;
         expect(scope.variables).to.have.length(2);
 
         // There's no "arguments"
@@ -77,7 +77,7 @@ describe("ES6 arrow function expression", () => {
         scope = scopeManager.scopes[1];
         expect(scope.type).to.be.equal("function");
         expect(scope.block.type).to.be.equal("ArrowFunctionExpression");
-        expect(scope.isStrict).to.be.true;
+        expect(scope.isStrict).to.be.false;
         expect(scope.variables).to.have.length(4);
 
         // There's no "arguments"
@@ -85,6 +85,57 @@ describe("ES6 arrow function expression", () => {
         expect(scope.variables[1].name).to.be.equal("b");
         expect(scope.variables[2].name).to.be.equal("c");
         expect(scope.variables[3].name).to.be.equal("d");
+    });
+
+    it("inherits upper scope strictness", () => {
+        const ast = espree(`
+            "use strict";
+            var arrow = () => {};
+        `);
+
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
+        expect(scopeManager.scopes).to.have.length(2);
+
+        let scope = scopeManager.scopes[0];
+
+        expect(scope.type).to.be.equal("global");
+        expect(scope.block.type).to.be.equal("Program");
+        expect(scope.isStrict).to.be.true;
+        expect(scope.variables).to.have.length(1);
+
+        scope = scopeManager.scopes[1];
+
+        expect(scope.type).to.be.equal("function");
+        expect(scope.block.type).to.be.equal("ArrowFunctionExpression");
+        expect(scope.isStrict).to.be.true;
+        expect(scope.variables).to.have.length(0);
+    });
+
+    it("is strict when a strictness directive is used", () => {
+        const ast = espree(`
+            var arrow = () => {
+                "use strict";
+            };
+        `);
+
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
+        expect(scopeManager.scopes).to.have.length(2);
+
+        let scope = scopeManager.scopes[0];
+
+        expect(scope.type).to.be.equal("global");
+        expect(scope.block.type).to.be.equal("Program");
+        expect(scope.isStrict).to.be.false;
+        expect(scope.variables).to.have.length(1);
+
+        scope = scopeManager.scopes[1];
+
+        expect(scope.type).to.be.equal("function");
+        expect(scope.block.type).to.be.equal("ArrowFunctionExpression");
+        expect(scope.isStrict).to.be.true;
+        expect(scope.variables).to.have.length(0);
     });
 });
 

--- a/tests/es6-arrow-function-expression.js
+++ b/tests/es6-arrow-function-expression.js
@@ -137,6 +137,21 @@ describe("ES6 arrow function expression", () => {
         expect(scope.isStrict).to.be.true;
         expect(scope.variables).to.have.length(0);
     });
+
+    it("works with no body", () => {
+        const ast = espree("var arrow = a => a;");
+
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
+
+        expect(scopeManager.scopes).to.have.length(2);
+
+        const scope = scopeManager.scopes[1];
+
+        expect(scope.type).to.be.equal("function");
+        expect(scope.block.type).to.be.equal("ArrowFunctionExpression");
+        expect(scope.isStrict).to.be.false;
+        expect(scope.variables).to.have.length(1);
+    });
 });
 
 // vim: set sw=4 ts=4 et tw=80 :


### PR DESCRIPTION
Fixes #49 

This has the original (broken) commit from #50 cherry-picked, and a separate a4ee79e commit fixing the `.length` error from #51.

I found linking (`npm link`) `eslint-scope` into `eslint` and running eslint's unit tests helpful, maybe this could be part of the `eslint-scope`'s CI checks?