### PR TITLE
Upgrade: update dependencies after dropping support for Node <8

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+!.eslintrc.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,16 @@
+"use strict";
+
+module.exports = {
+    root: true,
+    extends: [
+        "eslint"
+    ],
+    overrides: [
+        {
+            files: ["tests/**/*"],
+            env: {
+                mocha: true
+            }
+        }
+    ]
+};

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,7 +1,0 @@
-env:
-    node: true
-    es6: true
-parserOptions:
-    ecmaVersion: 6
-
-extends: eslint

--- a/Makefile.js
+++ b/Makefile.js
@@ -84,8 +84,6 @@ target.test = function() {
     let errors = 0;
     const lastReturn = exec(`${ISTANBUL} cover ${MOCHA} -- -R progress -c ${TEST_FILES}`);
 
-
-
     if (lastReturn.code !== 0) {
         errors++;
     }
@@ -131,8 +129,7 @@ target.checkLicenses = function() {
             impermissible.forEach(dependency => {
                 console.error("%s license for %s is impermissible.",
                     dependency.licenses,
-                    dependency.name
-                );
+                    dependency.name);
             });
             exit(1);
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,7 @@ function defaultOptions() {
         directive: false,
         nodejsScope: false,
         impliedStrict: false,
-        sourceType: "script",  // one of ['script', 'module']
+        sourceType: "script", // one of ['script', 'module']
         ecmaVersion: 5,
         childVisitorKeys: null,
         fallback: "iteration"
@@ -93,7 +93,7 @@ function updateDeeply(target, override) {
     }
 
     for (const key in override) {
-        if (override.hasOwnProperty(key)) {
+        if (Object.prototype.hasOwnProperty.call(override, key)) {
             const val = override[key];
 
             if (isHashObject(val)) {

--- a/lib/referencer.js
+++ b/lib/referencer.js
@@ -81,7 +81,7 @@ class Importer extends esrecurse.Visitor {
                     this.declaration,
                     null,
                     null
-                    ));
+                ));
         });
     }
 
@@ -151,20 +151,26 @@ class Referencer extends esrecurse.Visitor {
                 assignment.right,
                 maybeImplicitGlobal,
                 pattern !== assignment.left,
-                init);
+                init
+            );
         });
     }
 
     visitPattern(node, options, callback) {
+        let visitPatternOptions = options;
+        let visitPatternCallback = callback;
+
         if (typeof options === "function") {
-            callback = options;
-            options = { processRightHandNodes: false };
+            visitPatternCallback = options;
+            visitPatternOptions = { processRightHandNodes: false };
         }
+
         traverseIdentifierInPattern(
             this.options,
             node,
-            options.processRightHandNodes ? this : null,
-            callback);
+            visitPatternOptions.processRightHandNodes ? this : null,
+            visitPatternCallback
+        );
     }
 
     visitFunction(node) {
@@ -180,14 +186,14 @@ class Referencer extends esrecurse.Visitor {
 
             // id is defined in upper scope
             this.currentScope().__define(node.id,
-                    new Definition(
-                        Variable.FunctionName,
-                        node.id,
-                        node,
-                        null,
-                        null,
-                        null
-                    ));
+                new Definition(
+                    Variable.FunctionName,
+                    node.id,
+                    node,
+                    null,
+                    null,
+                    null
+                ));
         }
 
         // FunctionExpression with name creates its special scope;
@@ -258,14 +264,14 @@ class Referencer extends esrecurse.Visitor {
     visitClass(node) {
         if (node.type === Syntax.ClassDeclaration) {
             this.currentScope().__define(node.id,
-                    new Definition(
-                        Variable.ClassName,
-                        node.id,
-                        node,
-                        null,
-                        null,
-                        null
-                    ));
+                new Definition(
+                    Variable.ClassName,
+                    node.id,
+                    node,
+                    null,
+                    null,
+                    null
+                ));
         }
 
         this.visit(node.superClass);
@@ -274,11 +280,11 @@ class Referencer extends esrecurse.Visitor {
 
         if (node.id) {
             this.currentScope().__define(node.id,
-                    new Definition(
-                        Variable.ClassName,
-                        node.id,
-                        node
-                    ));
+                new Definition(
+                    Variable.ClassName,
+                    node.id,
+                    node
+                ));
         }
         this.visit(node.body);
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -161,7 +161,7 @@ class Scope {
          */
         this.type = type;
 
-         /**
+        /**
          * The scoped {@link Variable}s of this scope, as <code>{ Variable.name
          * : Variable }</code>.
          * @member {Map} Scope#set
@@ -192,13 +192,13 @@ class Scope {
          */
         this.block = block;
 
-         /**
+        /**
          * The {@link Reference|references} that are not resolved with this scope.
          * @member {Reference[]} Scope#through
          */
         this.through = [];
 
-         /**
+        /**
          * The scoped {@link Variable}s of this scope. In the case of a
          * 'function' scope this includes the automatic argument <em>arguments</em> as
          * its first element, as well as all further formal arguments.
@@ -206,7 +206,7 @@ class Scope {
          */
         this.variables = [];
 
-         /**
+        /**
          * Any variable {@link Reference|reference} found in this scope. This
          * includes occurrences of local variables as well as variables from
          * parent scopes (including the global scope). For local variables
@@ -217,7 +217,7 @@ class Scope {
          */
         this.references = [];
 
-         /**
+        /**
          * For 'global' and 'function' scopes, this is a self-reference. For
          * other scope types this is the <em>variableScope</em> value of the
          * parent scope.
@@ -226,38 +226,38 @@ class Scope {
         this.variableScope =
             (this.type === "global" || this.type === "function" || this.type === "module") ? this : upperScope.variableScope;
 
-         /**
+        /**
          * Whether this scope is created by a FunctionExpression.
          * @member {boolean} Scope#functionExpressionScope
          */
         this.functionExpressionScope = false;
 
-         /**
+        /**
          * Whether this is a scope that contains an 'eval()' invocation.
          * @member {boolean} Scope#directCallToEvalScope
          */
         this.directCallToEvalScope = false;
 
-         /**
+        /**
          * @member {boolean} Scope#thisFound
          */
         this.thisFound = false;
 
         this.__left = [];
 
-         /**
+        /**
          * Reference to the parent {@link Scope|scope}.
          * @member {Scope} Scope#upper
          */
         this.upper = upperScope;
 
-         /**
+        /**
          * Whether 'use strict' is in effect in this scope.
          * @member {boolean} Scope#isStrict
          */
         this.isStrict = isStrictScope(this, block, isMethodDefinition, scopeManager.__useDirective());
 
-         /**
+        /**
          * List of nested {@link Scope}s.
          * @member {Scope[]} Scope#childScopes
          */
@@ -414,11 +414,12 @@ class Scope {
     __define(node, def) {
         if (node && node.type === Syntax.Identifier) {
             this.__defineGeneric(
-                    node.name,
-                    this.set,
-                    this.variables,
-                    node,
-                    def);
+                node.name,
+                this.set,
+                this.variables,
+                node,
+                def
+            );
         }
     }
 
@@ -550,14 +551,14 @@ class GlobalScope extends Scope {
             const info = implicit[i];
 
             this.__defineImplicit(info.pattern,
-                    new Definition(
-                        Variable.ImplicitGlobalVariable,
-                        info.pattern,
-                        info.node,
-                        null,
-                        null,
-                        null
-                    ));
+                new Definition(
+                    Variable.ImplicitGlobalVariable,
+                    info.pattern,
+                    info.node,
+                    null,
+                    null,
+                    null
+                ));
 
         }
 
@@ -569,11 +570,12 @@ class GlobalScope extends Scope {
     __defineImplicit(node, def) {
         if (node && node.type === Syntax.Identifier) {
             this.__defineGeneric(
-                    node.name,
-                    this.implicit.set,
-                    this.implicit.variables,
-                    node,
-                    def);
+                node.name,
+                this.implicit.set,
+                this.implicit.variables,
+                node,
+                def
+            );
         }
     }
 }
@@ -588,14 +590,14 @@ class FunctionExpressionNameScope extends Scope {
     constructor(scopeManager, upperScope, block) {
         super(scopeManager, "function-expression-name", upperScope, block, false);
         this.__define(block.id,
-                new Definition(
-                    Variable.FunctionName,
-                    block.id,
-                    block,
-                    null,
-                    null,
-                    null
-                ));
+            new Definition(
+                Variable.FunctionName,
+                block.id,
+                block,
+                null,
+                null,
+                null
+            ));
         this.functionExpressionScope = true;
     }
 }
@@ -684,11 +686,12 @@ class FunctionScope extends Scope {
 
     __defineArguments() {
         this.__defineGeneric(
-                "arguments",
-                this.set,
-                this.variables,
-                null,
-                null);
+            "arguments",
+            this.set,
+            this.variables,
+            null,
+            null
+        );
         this.taints.set("arguments", true);
     }
 
@@ -710,7 +713,7 @@ class FunctionScope extends Scope {
         // It's invalid resolution in the following case:
         return !(
             variable.scope === this &&
-            ref.identifier.range[0] < bodyStart &&                 // the reference is in the parameter part.
+            ref.identifier.range[0] < bodyStart && // the reference is in the parameter part.
             variable.defs.every(d => d.name.range[0] >= bodyStart) // the variable is in the body.
         );
     }

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   "devDependencies": {
     "@typescript-eslint/parser": "^1.11.0",
     "chai": "^4.2.0",
-    "eslint": "^6.0.1",
+    "eslint": "^5.16.0",
     "eslint-config-eslint": "^5.0.1",
-    "eslint-plugin-node": "^9.1.0",
+    "eslint-plugin-node": "^8.0.1",
     "eslint-release": "^1.0.0",
     "espree": "^6.0.0",
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   "devDependencies": {
     "@typescript-eslint/parser": "^1.11.0",
     "chai": "^4.2.0",
-    "eslint": "^5.16.0",
+    "eslint": "^6.0.1",
     "eslint-config-eslint": "^5.0.1",
-    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-node": "^9.1.0",
     "eslint-release": "^1.0.0",
     "espree": "^6.0.0",
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -31,16 +31,17 @@
     "estraverse": "^4.1.1"
   },
   "devDependencies": {
-    "chai": "^3.4.1",
-    "eslint": "^3.15.0",
-    "eslint-config-eslint": "^4.0.0",
+    "@typescript-eslint/parser": "^1.11.0",
+    "chai": "^4.2.0",
+    "eslint": "^6.0.1",
+    "eslint-config-eslint": "^5.0.1",
+    "eslint-plugin-node": "^9.1.0",
     "eslint-release": "^1.0.0",
-    "espree": "^3.1.1",
+    "espree": "^6.0.0",
     "istanbul": "^0.4.5",
-    "mocha": "^3.2.0",
+    "mocha": "^6.1.4",
     "npm-license": "^0.3.3",
-    "shelljs": "^0.7.6",
-    "typescript": "~2.0.10",
-    "typescript-eslint-parser": "^1.0.0"
+    "shelljs": "^0.8.3",
+    "typescript": "^3.5.2"
   }
 }

--- a/tests/.eslintrc.yml
+++ b/tests/.eslintrc.yml
@@ -1,4 +1,0 @@
-env:
-    mocha: true
-
-extends: '../.eslintrc.yml'

--- a/tests/es6-block-scope.js
+++ b/tests/es6-block-scope.js
@@ -39,16 +39,16 @@ describe("ES6 block scope", () => {
 
         const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-        expect(scopeManager.scopes).to.have.length(2);  // Program and BlcokStatement scope.
+        expect(scopeManager.scopes).to.have.length(2); // Program and BlockStatement scope.
 
         let scope = scopeManager.scopes[0];
 
         expect(scope.type).to.be.equal("global");
-        expect(scope.variables).to.have.length(0);  // No variable in Program scope.
+        expect(scope.variables).to.have.length(0); // No variable in Program scope.
 
         scope = scopeManager.scopes[1];
         expect(scope.type).to.be.equal("block");
-        expect(scope.variables).to.have.length(1);  // `i` in block scope.
+        expect(scope.variables).to.have.length(1); // `i` in block scope.
         expect(scope.variables[0].name).to.be.equal("i");
         expect(scope.references).to.have.length(2);
         expect(scope.references[0].identifier.name).to.be.equal("i");

--- a/tests/es6-default-parameters.js
+++ b/tests/es6-default-parameters.js
@@ -46,11 +46,11 @@ describe("ES6 default parameters:", () => {
 
                 const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-                expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
+                expect(scopeManager.scopes).to.have.length(2); // [global, foo]
 
                 const scope = scopeManager.scopes[1];
 
-                expect(scope.variables).to.have.length(numVars);  // [arguments?, a, b]
+                expect(scope.variables).to.have.length(numVars); // [arguments?, a, b]
                 expect(scope.references).to.have.length(1);
 
                 const reference = scope.references[0];
@@ -90,12 +90,12 @@ describe("ES6 default parameters:", () => {
 
                 const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-                expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
+                expect(scopeManager.scopes).to.have.length(2); // [global, foo]
 
                 const scope = scopeManager.scopes[1];
 
-                expect(scope.variables).to.have.length(numVars);  // [arguments?, b]
-                expect(scope.references).to.have.length(2);  // [b, a]
+                expect(scope.variables).to.have.length(numVars); // [arguments?, b]
+                expect(scope.references).to.have.length(2); // [b, a]
 
                 const reference = scope.references[1];
 
@@ -134,12 +134,12 @@ describe("ES6 default parameters:", () => {
 
                 const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-                expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
+                expect(scopeManager.scopes).to.have.length(2); // [global, foo]
 
                 const scope = scopeManager.scopes[1];
 
-                expect(scope.variables).to.have.length(numVars);  // [arguments?, b]
-                expect(scope.references).to.have.length(2);  // [b, a]
+                expect(scope.variables).to.have.length(numVars); // [arguments?, b]
+                expect(scope.references).to.have.length(2); // [b, a]
 
                 const reference = scope.references[1];
 
@@ -178,12 +178,12 @@ describe("ES6 default parameters:", () => {
 
                 const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-                expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
+                expect(scopeManager.scopes).to.have.length(2); // [global, foo]
 
                 const scope = scopeManager.scopes[1];
 
-                expect(scope.variables).to.have.length(numVars);  // [arguments?, b]
-                expect(scope.references).to.have.length(2);  // [b, a]
+                expect(scope.variables).to.have.length(numVars); // [arguments?, b]
+                expect(scope.references).to.have.length(2); // [b, a]
 
                 const reference = scope.references[1];
 
@@ -221,12 +221,12 @@ describe("ES6 default parameters:", () => {
 
                 const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-                expect(scopeManager.scopes).to.have.length(3);  // [global, foo, anonymous]
+                expect(scopeManager.scopes).to.have.length(3); // [global, foo, anonymous]
 
                 const scope = scopeManager.scopes[2];
 
-                expect(scope.variables).to.have.length(1);  // [arguments]
-                expect(scope.references).to.have.length(1);  // [a]
+                expect(scope.variables).to.have.length(1); // [arguments]
+                expect(scope.references).to.have.length(1); // [a]
 
                 const reference = scope.references[0];
 
@@ -265,12 +265,12 @@ describe("ES6 default parameters:", () => {
 
                 const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-                expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
+                expect(scopeManager.scopes).to.have.length(2); // [global, foo]
 
                 const scope = scopeManager.scopes[1];
 
-                expect(scope.variables).to.have.length(numVars);  // [arguments?, b, a]
-                expect(scope.references).to.have.length(2);  // [b, a]
+                expect(scope.variables).to.have.length(numVars); // [arguments?, b, a]
+                expect(scope.references).to.have.length(2); // [b, a]
 
                 const reference = scope.references[1];
 
@@ -309,12 +309,12 @@ describe("ES6 default parameters:", () => {
 
                 const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-                expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
+                expect(scopeManager.scopes).to.have.length(2); // [global, foo]
 
                 const scope = scopeManager.scopes[1];
 
-                expect(scope.variables).to.have.length(numVars);  // [arguments?, b, a]
-                expect(scope.references).to.have.length(2);  // [b, a]
+                expect(scope.variables).to.have.length(numVars); // [arguments?, b, a]
+                expect(scope.references).to.have.length(2); // [b, a]
 
                 const reference = scope.references[1];
 
@@ -352,11 +352,11 @@ describe("ES6 default parameters:", () => {
 
                 const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-                expect(scopeManager.scopes).to.have.length(3);  // [global, foo, anonymous function]
+                expect(scopeManager.scopes).to.have.length(3); // [global, foo, anonymous function]
 
                 const scope = scopeManager.scopes[2];
 
-                expect(scope.references).to.have.length(1);  // [a]
+                expect(scope.references).to.have.length(1); // [a]
 
                 const reference = scope.references[0];
 

--- a/tests/es6-destructuring-assignments.js
+++ b/tests/es6-destructuring-assignments.js
@@ -81,7 +81,7 @@ describe("ES6 destructuring assignments", () => {
 
         const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-        expect(scopeManager.scopes).to.have.length(3);  // [global, function, for]
+        expect(scopeManager.scopes).to.have.length(3); // [global, function, for]
 
         let scope = scopeManager.scopes[0];
 
@@ -176,7 +176,7 @@ describe("ES6 destructuring assignments", () => {
 
         const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-        expect(scopeManager.scopes).to.have.length(3);  // [global, function, for]
+        expect(scopeManager.scopes).to.have.length(3); // [global, function, for]
 
         let scope = scopeManager.scopes[0];
 
@@ -299,7 +299,7 @@ describe("ES6 destructuring assignments", () => {
 
         const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-        expect(scopeManager.scopes).to.have.length(3);  // [global, function, for]
+        expect(scopeManager.scopes).to.have.length(3); // [global, function, for]
 
         let scope = scopeManager.scopes[0];
 
@@ -440,15 +440,15 @@ describe("ES6 destructuring assignments", () => {
         expect(scope.variables[0].name).to.equal("arguments");
         expect(scope.variables[1].name).to.equal("obj");
         expect(scope.references).to.have.length(5);
-        expect(scope.references[0].identifier.name).to.equal("obj");  // obj.a
+        expect(scope.references[0].identifier.name).to.equal("obj"); // obj.a
         expect(scope.references[0].isWrite()).to.be.false;
         expect(scope.references[0].isRead()).to.be.true;
         expect(scope.references[0].resolved).to.equal(scope.variables[1]);
-        expect(scope.references[1].identifier.name).to.equal("obj");  // obj.b
+        expect(scope.references[1].identifier.name).to.equal("obj"); // obj.b
         expect(scope.references[1].isWrite()).to.be.false;
         expect(scope.references[1].isRead()).to.be.true;
         expect(scope.references[1].resolved).to.equal(scope.variables[1]);
-        expect(scope.references[2].identifier.name).to.equal("obj");  // obj.c
+        expect(scope.references[2].identifier.name).to.equal("obj"); // obj.c
         expect(scope.references[2].isWrite()).to.be.false;
         expect(scope.references[2].isRead()).to.be.true;
         expect(scope.references[2].resolved).to.equal(scope.variables[1]);

--- a/tests/es6-export.js
+++ b/tests/es6-export.js
@@ -29,7 +29,7 @@ const analyze = require("..").analyze;
 describe("export declaration", () => {
 
     // http://people.mozilla.org/~jorendorff/es6-draft.html#sec-static-and-runtme-semantics-module-records
-    it("should create vairable bindings", () => {
+    it("should create variable bindings", () => {
         const ast = espree("export var v;");
 
         const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "module" });
@@ -122,7 +122,7 @@ describe("export declaration", () => {
     });
 
     it("should refer exported references#1", () => {
-        const ast = espree("export {x};");
+        const ast = espree("const x = 1; export {x};");
 
         const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "module" });
 
@@ -136,13 +136,14 @@ describe("export declaration", () => {
         const scope = scopeManager.scopes[1];
 
         expect(scope.type).to.be.equal("module");
-        expect(scope.variables).to.have.length(0);
-        expect(scope.references).to.have.length(1);
+        expect(scope.variables).to.have.length(1);
+        expect(scope.references).to.have.length(2);
         expect(scope.references[0].identifier.name).to.be.equal("x");
+        expect(scope.references[1].identifier.name).to.be.equal("x");
     });
 
     it("should refer exported references#2", () => {
-        const ast = espree("export {v as x};");
+        const ast = espree("const v = 1; export {v as x};");
 
         const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "module" });
 
@@ -156,9 +157,10 @@ describe("export declaration", () => {
         const scope = scopeManager.scopes[1];
 
         expect(scope.type).to.be.equal("module");
-        expect(scope.variables).to.have.length(0);
-        expect(scope.references).to.have.length(1);
+        expect(scope.variables).to.have.length(1);
+        expect(scope.references).to.have.length(2);
         expect(scope.references[0].identifier.name).to.be.equal("v");
+        expect(scope.references[1].identifier.name).to.be.equal("v");
     });
 
     it("should not refer exported references from other source#1", () => {

--- a/tests/es6-super.js
+++ b/tests/es6-super.js
@@ -50,6 +50,7 @@ describe("ES6 super", () => {
         expect(scope.variables).to.have.length(1);
         expect(scope.variables[0].name).to.be.equal("Foo");
         expect(scope.references).to.have.length(1);
+        expect(scope.references[0].identifier.name).to.be.equal("Bar");
 
         scope = scopeManager.scopes[1];
         expect(scope.type).to.be.equal("class");

--- a/tests/es6-super.js
+++ b/tests/es6-super.js
@@ -29,7 +29,7 @@ const analyze = require("..").analyze;
 describe("ES6 super", () => {
     it("is not handled as reference", () => {
         const ast = espree(`
-            class Hello {
+            class Foo extends Bar {
                 constructor() {
                     super();
                 }
@@ -48,26 +48,26 @@ describe("ES6 super", () => {
 
         expect(scope.type).to.be.equal("global");
         expect(scope.variables).to.have.length(1);
-        expect(scope.variables[0].name).to.be.equal("Hello");
-        expect(scope.references).to.have.length(0);
+        expect(scope.variables[0].name).to.be.equal("Foo");
+        expect(scope.references).to.have.length(1);
 
         scope = scopeManager.scopes[1];
         expect(scope.type).to.be.equal("class");
         expect(scope.variables).to.have.length(1);
-        expect(scope.variables[0].name).to.be.equal("Hello");
+        expect(scope.variables[0].name).to.be.equal("Foo");
         expect(scope.references).to.have.length(0);
 
         scope = scopeManager.scopes[2];
         expect(scope.type).to.be.equal("function");
         expect(scope.variables).to.have.length(1);
         expect(scope.variables[0].name).to.be.equal("arguments");
-        expect(scope.references).to.have.length(0);  // super is specially handled like `this`.
+        expect(scope.references).to.have.length(0); // super is specially handled like `this`.
 
         scope = scopeManager.scopes[3];
         expect(scope.type).to.be.equal("function");
         expect(scope.variables).to.have.length(1);
         expect(scope.variables[0].name).to.be.equal("arguments");
-        expect(scope.references).to.have.length(0);  // super is specially handled like `this`.
+        expect(scope.references).to.have.length(0); // super is specially handled like `this`.
     });
 });
 

--- a/tests/get-declared-variables.js
+++ b/tests/get-declared-variables.js
@@ -207,8 +207,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", () => {
         const ast = espree(`
             import "aaa";
             import * as a from "bbb";
-            import b, {c, x as d} from "ccc";`
-        );
+            import b, {c, x as d} from "ccc";`);
 
         verify(ast, "ImportDeclaration", [
             [],
@@ -222,8 +221,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", () => {
         const ast = espree(`
             import "aaa";
             import * as a from "bbb";
-            import b, {c, x as d} from "ccc";`
-        );
+            import b, {c, x as d} from "ccc";`);
 
         verify(ast, "ImportSpecifier", [
             ["c"],
@@ -236,8 +234,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", () => {
         const ast = espree(`
             import "aaa";
             import * as a from "bbb";
-            import b, {c, x as d} from "ccc";`
-        );
+            import b, {c, x as d} from "ccc";`);
 
         verify(ast, "ImportDefaultSpecifier", [
             ["b"]
@@ -249,8 +246,7 @@ describe("ScopeManager.prototype.getDeclaredVariables", () => {
         const ast = espree(`
             import "aaa";
             import * as a from "bbb";
-            import b, {c, x as d} from "ccc";`
-        );
+            import b, {c, x as d} from "ccc";`);
 
         verify(ast, "ImportNamespaceSpecifier", [
             ["a"]

--- a/tests/implied-strict.js
+++ b/tests/implied-strict.js
@@ -107,8 +107,7 @@ describe("impliedStrict option", () => {
     });
 
     it("omits a module global scope when ensuring all user scopes are strict", () => {
-        const ast = espree(`
-            function foo() {}`);
+        const ast = espree("function foo() {}");
 
         const scopeManager = analyze(ast, { ecmaVersion: 6, impliedStrict: true, sourceType: "module" });
 

--- a/tests/implied-strict.js
+++ b/tests/implied-strict.js
@@ -108,8 +108,7 @@ describe("impliedStrict option", () => {
 
     it("omits a module global scope when ensuring all user scopes are strict", () => {
         const ast = espree(`
-            function foo() {}`
-        );
+            function foo() {}`);
 
         const scopeManager = analyze(ast, { ecmaVersion: 6, impliedStrict: true, sourceType: "module" });
 

--- a/tests/nodejs-scope.js
+++ b/tests/nodejs-scope.js
@@ -57,8 +57,7 @@ describe("nodejsScope option", () => {
 
     it("creates a function scope following the global scope immediately and creates module scope", () => {
         const ast = espree(`
-            import {x as v} from "mod";`
-        );
+            import {x as v} from "mod";`);
 
         const scopeManager = analyze(ast, { ecmaVersion: 6, nodejsScope: true, sourceType: "module" });
 

--- a/tests/nodejs-scope.js
+++ b/tests/nodejs-scope.js
@@ -56,8 +56,7 @@ describe("nodejsScope option", () => {
     });
 
     it("creates a function scope following the global scope immediately and creates module scope", () => {
-        const ast = espree(`
-            import {x as v} from "mod";`);
+        const ast = espree("import {x as v} from 'mod';");
 
         const scopeManager = analyze(ast, { ecmaVersion: 6, nodejsScope: true, sourceType: "module" });
 

--- a/tests/references.js
+++ b/tests/references.js
@@ -62,12 +62,12 @@ describe("References:", () => {
 
             const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-            expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
+            expect(scopeManager.scopes).to.have.length(2); // [global, foo]
 
             const scope = scopeManager.scopes[1];
 
-            expect(scope.variables).to.have.length(2);  // [arguments, b]
-            expect(scope.references).to.have.length(2);  // [b, a]
+            expect(scope.variables).to.have.length(2); // [arguments, b]
+            expect(scope.references).to.have.length(2); // [b, a]
 
             const reference = scope.references[1];
 
@@ -88,12 +88,12 @@ describe("References:", () => {
 
             const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-            expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
+            expect(scopeManager.scopes).to.have.length(2); // [global, foo]
 
             const scope = scopeManager.scopes[1];
 
-            expect(scope.variables).to.have.length(2);  // [arguments, b]
-            expect(scope.references).to.have.length(2);  // [b, a]
+            expect(scope.variables).to.have.length(2); // [arguments, b]
+            expect(scope.references).to.have.length(2); // [b, a]
 
             const reference = scope.references[1];
 
@@ -139,12 +139,12 @@ describe("References:", () => {
 
             const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-            expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
+            expect(scopeManager.scopes).to.have.length(2); // [global, foo]
 
             const scope = scopeManager.scopes[1];
 
-            expect(scope.variables).to.have.length(2);  // [arguments, b]
-            expect(scope.references).to.have.length(2);  // [b, a]
+            expect(scope.variables).to.have.length(2); // [arguments, b]
+            expect(scope.references).to.have.length(2); // [b, a]
 
             const reference = scope.references[1];
 
@@ -190,12 +190,12 @@ describe("References:", () => {
 
             const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-            expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
+            expect(scopeManager.scopes).to.have.length(2); // [global, foo]
 
             const scope = scopeManager.scopes[1];
 
-            expect(scope.variables).to.have.length(2);  // [arguments, b]
-            expect(scope.references).to.have.length(2);  // [b, a]
+            expect(scope.variables).to.have.length(2); // [arguments, b]
+            expect(scope.references).to.have.length(2); // [b, a]
 
             const reference = scope.references[1];
 
@@ -217,7 +217,7 @@ describe("References:", () => {
 
             const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-            expect(scopeManager.scopes).to.have.length(2);  // [global, a]
+            expect(scopeManager.scopes).to.have.length(2); // [global, a]
 
             const scope = scopeManager.scopes[0];
 
@@ -244,12 +244,12 @@ describe("References:", () => {
 
             const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-            expect(scopeManager.scopes).to.have.length(3);  // [global, a, foo]
+            expect(scopeManager.scopes).to.have.length(3); // [global, a, foo]
 
             const scope = scopeManager.scopes[2];
 
-            expect(scope.variables).to.have.length(2);  // [arguments, b]
-            expect(scope.references).to.have.length(2);  // [b, a]
+            expect(scope.variables).to.have.length(2); // [arguments, b]
+            expect(scope.references).to.have.length(2); // [b, a]
 
             const reference = scope.references[1];
 
@@ -271,12 +271,12 @@ describe("References:", () => {
 
             const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-            expect(scopeManager.scopes).to.have.length(2);  // [global, A]
+            expect(scopeManager.scopes).to.have.length(2); // [global, A]
 
             const scope = scopeManager.scopes[0];
 
-            expect(scope.variables).to.have.length(2);  // [A, b]
-            expect(scope.references).to.have.length(2);  // [b, A]
+            expect(scope.variables).to.have.length(2); // [A, b]
+            expect(scope.references).to.have.length(2); // [b, A]
 
             const reference = scope.references[1];
 
@@ -298,12 +298,12 @@ describe("References:", () => {
 
             const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-            expect(scopeManager.scopes).to.have.length(3);  // [global, A, foo]
+            expect(scopeManager.scopes).to.have.length(3); // [global, A, foo]
 
             const scope = scopeManager.scopes[2];
 
-            expect(scope.variables).to.have.length(2);  // [arguments, b]
-            expect(scope.references).to.have.length(2);  // [b, A]
+            expect(scope.variables).to.have.length(2); // [arguments, b]
+            expect(scope.references).to.have.length(2); // [b, A]
 
             const reference = scope.references[1];
 
@@ -326,11 +326,11 @@ describe("References:", () => {
 
             const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-            expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
+            expect(scopeManager.scopes).to.have.length(2); // [global, foo]
 
             const scope = scopeManager.scopes[1];
 
-            expect(scope.variables).to.have.length(2);  // [arguments, a]
+            expect(scope.variables).to.have.length(2); // [arguments, a]
             expect(scope.references).to.have.length(1);
 
             const reference = scope.references[0];
@@ -355,12 +355,12 @@ describe("References:", () => {
 
             const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-            expect(scopeManager.scopes).to.have.length(3);  // [global, foo, bar]
+            expect(scopeManager.scopes).to.have.length(3); // [global, foo, bar]
 
             const scope = scopeManager.scopes[2];
 
-            expect(scope.variables).to.have.length(2);  // [arguments, b]
-            expect(scope.references).to.have.length(2);  // [b, a]
+            expect(scope.variables).to.have.length(2); // [arguments, b]
+            expect(scope.references).to.have.length(2); // [b, a]
 
             const reference = scope.references[1];
 
@@ -383,11 +383,11 @@ describe("References:", () => {
 
             const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-            expect(scopeManager.scopes).to.have.length(2);  // [global, foo]
+            expect(scopeManager.scopes).to.have.length(2); // [global, foo]
 
             const scope = scopeManager.scopes[1];
 
-            expect(scope.variables).to.have.length(2);  // [arguments, a]
+            expect(scope.variables).to.have.length(2); // [arguments, a]
             expect(scope.references).to.have.length(1);
 
             const reference = scope.references[0];
@@ -412,12 +412,12 @@ describe("References:", () => {
 
             const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-            expect(scopeManager.scopes).to.have.length(3);  // [global, foo, bar]
+            expect(scopeManager.scopes).to.have.length(3); // [global, foo, bar]
 
             const scope = scopeManager.scopes[2];
 
-            expect(scope.variables).to.have.length(2);  // [arguments, b]
-            expect(scope.references).to.have.length(2);  // [b, a]
+            expect(scope.variables).to.have.length(2); // [arguments, b]
+            expect(scope.references).to.have.length(2); // [b, a]
 
             const reference = scope.references[1];
 
@@ -551,8 +551,7 @@ describe("References:", () => {
                     expect(reference.isWrite()).to.be.true;
                     expect(reference.init).to.be.true;
                 });
-            })
-        );
+            }));
 
         let falseCodes = [
             "let a; a = 0;",
@@ -586,8 +585,7 @@ describe("References:", () => {
                     expect(reference.isWrite()).to.be.true;
                     expect(reference.init).to.be.false;
                 });
-            })
-        );
+            }));
 
         falseCodes = [
             "let a; let b = a;",
@@ -626,8 +624,7 @@ describe("References:", () => {
                     expect(reference.isRead()).to.be.true;
                     expect(reference.init).to.be.undefined;
                 });
-            })
-        );
+            }));
     });
 });
 

--- a/tests/typescript.js
+++ b/tests/typescript.js
@@ -11,7 +11,7 @@
 //------------------------------------------------------------------------------
 
 const expect = require("chai").expect,
-    parse = require("typescript-eslint-parser").parse,
+    parse = require("@typescript-eslint/parser").parse,
     analyze = require("..").analyze;
 
 //------------------------------------------------------------------------------
@@ -31,39 +31,22 @@ describe("typescript", () => {
 
             const scopeManager = analyze(ast);
 
-            expect(scopeManager.scopes).to.have.length(4);
+            expect(scopeManager.scopes).to.have.length(2);
 
             const globalScope = scopeManager.scopes[0];
 
             expect(globalScope.type).to.be.equal("global");
             expect(globalScope.variables).to.have.length(1);
-            expect(globalScope.references).to.have.length(0);
+            expect(globalScope.references).to.have.length(4);
             expect(globalScope.isArgumentsMaterialized()).to.be.true;
 
-            // Function scopes
-            let scope = scopeManager.scopes[1];
+            const scope = scopeManager.scopes[1];
 
-            expect(scope.type).to.be.equal("function");
-            expect(scope.variables).to.have.length(2);
-            expect(scope.variables[0].name).to.be.equal("arguments");
-            expect(scope.isArgumentsMaterialized()).to.be.false;
-            expect(scope.references).to.have.length(0);
-
-            scope = scopeManager.scopes[2];
-            expect(scope.type).to.be.equal("function");
-            expect(scope.variables).to.have.length(2);
-            expect(scope.variables[0].name).to.be.equal("arguments");
-            expect(scope.isArgumentsMaterialized()).to.be.false;
-            expect(scope.references).to.have.length(0);
-
-            scope = scopeManager.scopes[3];
             expect(scope.type).to.be.equal("function");
             expect(scope.variables).to.have.length(2);
             expect(scope.variables[0].name).to.be.equal("arguments");
             expect(scope.isArgumentsMaterialized()).to.be.false;
             expect(scope.references).to.have.length(1);
-
-
         });
     });
 });


### PR DESCRIPTION
This PR updates some outdated dependencies. I have also run the autofixer and will comment on places I manually changed things.

I haven't worked in this repository very much, so I'd really love feedback/reviews from others! I'm specifically unsure of the TypeScript change (though I think what I have here makes sense?).

~CI is failing in Node <=6 because we've dropped support in ESLint v6. Should we also drop support and do a major release of `eslint-scope`?~

~__Edit:__ PR can be found [here](https://github.com/eslint/eslint-scope/pull/54).~
~__Edit 2:__ As mentioned in https://github.com/eslint/eslint-scope/pull/54, Webpack relies on this package directly and still supports Node@6. Maybe we want to keep support for Node 6 (and just drop support for Node 4)? We won't be able to upgrade to the latest version of ESLint in our devDependencies, though.~

~I've downgraded ESLint to v5 and it now passes CI in Node 6, however this still fails in Node 4. At this point, I guess we should just wait until we drop Node <8.~

__Edit 3:__ The TSC resolved to drop Node <8 for this package. See https://github.com/eslint/eslint-scope/pull/54.