### PR TITLE
Breaking: drop support for Node v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-    - "4"
-    - "6"
     - "8"
     - "9"
     - "10"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "version": "4.0.3",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   },
   "repository": "eslint/eslint-scope",
   "bugs": {


### PR DESCRIPTION
refs https://github.com/eslint/eslint-scope/pull/53

Now that we've dropped support for Node <8, I think we should also drop support here. I'd like to merge this, merge https://github.com/eslint/eslint-scope/pull/53, and then cut a major release.

~~__Edit:__ @ilyavolodin made me aware that Webpack depends on `eslint-scope` directly, and it appears that they still support Node@6. Maybe this isn't something we want to do yet?~~

This was [discussed by the TSC](https://github.com/eslint/eslint-scope/pull/54#issuecomment-513060862), who resolved to accept this.