### PR TITLE
Updated `esrecurse` to ^4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lib"
   ],
   "dependencies": {
-    "esrecurse": "^4.1.0",
+    "esrecurse": "^4.3.0",
     "estraverse": "^4.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated esrecurse version to support latest estraverse with optional chaining support


https://github.com/estools/esrecurse/pull/22