### PR TITLE
Upgrade: estraverse to version 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "esrecurse": "^4.3.0",
-    "estraverse": "^4.1.1"
+    "estraverse": "^5.2.0"
   },
   "devDependencies": {
     "@typescript-eslint/parser": "^1.11.0",


### PR DESCRIPTION
This will help reduce the install size of eslint since both `esrecurse` and `esquery` already have a dependency on estraverse 5.

The only breaking change in estraverse 5 is the removal of the version property: https://github.com/estools/estraverse/commit/f522cbe05b1e71ba8243232012f86e00b4d8b06a

This can safely go out as a patch release.