### PR TITLE
build: upgrade eslint-release to v3.2.0 to support conventional commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-config-eslint": "^7.0.0",
     "eslint-plugin-jsdoc": "^35.4.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-release": "^3.1.2",
+    "eslint-release": "^3.2.0",
     "eslint-visitor-keys": "^3.0.0",
     "espree": "^8.0.0",
     "mocha": "^9.0.1",


### PR DESCRIPTION
Updates eslint-release dependency to the latest v3.2.0, which supports conventional commits.