### PR TITLE
feat: Add sourceType:commonjs support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,7 @@ function defaultOptions() {
         directive: false,
         nodejsScope: false,
         impliedStrict: false,
-        sourceType: "script", // one of ['script', 'module']
+        sourceType: "script", // one of ['script', 'module', 'commonjs']
         ecmaVersion: 5,
         childVisitorKeys: null,
         fallback: "iteration"
@@ -122,7 +122,7 @@ function updateDeeply(target, override) {
  * a function scope immediately following the global scope.
  * @param {boolean} [providedOptions.impliedStrict=false] implied strict mode
  * (if ecmaVersion >= 5).
- * @param {string} [providedOptions.sourceType='script'] the source type of the script. one of 'script' and 'module'
+ * @param {string} [providedOptions.sourceType='script'] the source type of the script. one of 'script', 'module', and 'commonjs'
  * @param {number} [providedOptions.ecmaVersion=5] which ECMAScript version is considered
  * @param {Object} [providedOptions.childVisitorKeys=null] Additional known visitor keys. See [esrecurse](https://github.com/estools/esrecurse)'s the `childVisitorKeys` option.
  * @param {string} [providedOptions.fallback='iteration'] A kind of the fallback in order to encounter with unknown node. See [esrecurse](https://github.com/estools/esrecurse)'s the `fallback` option.

--- a/lib/scope-manager.js
+++ b/lib/scope-manager.js
@@ -66,7 +66,7 @@ class ScopeManager {
     }
 
     __isNodejsScope() {
-        return this.__options.nodejsScope;
+        return this.__options.nodejsScope || this.__options.sourceType === "commonjs";
     }
 
     isModule() {

--- a/tests/nodejs-scope.js
+++ b/tests/nodejs-scope.js
@@ -28,13 +28,40 @@ import espree from "./util/espree.js";
 import { analyze } from "../lib/index.js";
 
 describe("nodejsScope option", () => {
-    it("creates a function scope following the global scope immediately", () => {
+
+    it("creates a function scope following the global scope immediately when nodejscope: true", () => {
         const ast = espree(`
             "use strict";
             var hello = 20;
         `);
 
         const scopeManager = analyze(ast, { ecmaVersion: 6, nodejsScope: true });
+
+        expect(scopeManager.scopes).to.have.length(2);
+
+        let scope = scopeManager.scopes[0];
+
+        expect(scope.type).to.be.equal("global");
+        expect(scope.block.type).to.be.equal("Program");
+        expect(scope.isStrict).to.be.false;
+        expect(scope.variables).to.have.length(0);
+
+        scope = scopeManager.scopes[1];
+        expect(scope.type).to.be.equal("function");
+        expect(scope.block.type).to.be.equal("Program");
+        expect(scope.isStrict).to.be.true;
+        expect(scope.variables).to.have.length(2);
+        expect(scope.variables[0].name).to.be.equal("arguments");
+        expect(scope.variables[1].name).to.be.equal("hello");
+    });
+
+    it("creates a function scope following the global scope immediately when sourceType:commonjs", () => {
+        const ast = espree(`
+            "use strict";
+            var hello = 20;
+        `);
+
+        const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "commonjs" });
 
         expect(scopeManager.scopes).to.have.length(2);
 


### PR DESCRIPTION
Adds `sourceType:commonjs` support so that passing this option is equivalent to setting `nodejsScope: true`.

Related: https://github.com/eslint/espree/pull/520