### PR TITLE
ci: use node v16 for `Lint` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '16.x'
       - name: Install dependencies
         run: npm install
       - name: Lint files


### PR DESCRIPTION
Use Node.js v16 for CI jobs.