### PR TITLE
update package.json export field

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
       "import": "./lib/index.js",
       "require": "./dist/eslint-scope.cjs"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./lib/referencer.js": {
+      "import": "./lib/referencer.js",
+      "require": "./lib/referencer.js"
+    }
   },
   "version": "7.1.1",
   "engines": {


### PR DESCRIPTION
Hello!
update to node-eslint-scope caused breaking changes to webpack5.65.0 reversed dependencies while building as most submodules that used to be exported by default in the `package.json`  file are now selected in the new version `7.1.1`

here is the error message thrown for most if webpack5.65.0 reverse dependencies (e.g `stats-webpack-plugin`)

```
     2) StatsWebpackPlugin
       supports multi-compile mode and outputs one `stats.json` file: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/referencer' is not defined by "exports" in /usr/share/nodejs/eslint-scope/package.json
      at throwExportsNotFound (internal/modules/esm/resolve.js:299:9)
      at packageExportsResolve (internal/modules/esm/resolve.js:522:3)
      at resolveExports (internal/modules/cjs/loader.js:424:36)
      at Function.Module._findPath (internal/modules/cjs/loader.js:464:31)
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:802:27)
      at Function.Module._load (internal/modules/cjs/loader.js:667:27)
      at Module.require (internal/modules/cjs/loader.js:887:19)
      at require (internal/modules/cjs/helpers.js:74:18)
      at Object.<anonymous> 
(/usr/share/nodejs/webpack/lib/optimize/ConcatenatedModule.js:9:20)
      at Module._compile (internal/modules/cjs/loader.js:999:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
      at Module.load (internal/modules/cjs/loader.js:863:32)
      at Function.Module._load (internal/modules/cjs/loader.js:708:14)
      at Module.require (internal/modules/cjs/loader.js:887:19)
      at require (internal/modules/cjs/helpers.js:74:18)
      at Object.<anonymous> (/usr/share/nodejs/webpack/lib/optimize/ModuleConcatenationPlugin.js:21:28)
      at Module._compile (internal/modules/cjs/loader.js:999:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
      at Module.load (internal/modules/cjs/loader.js:863:32)
      at Function.Module._load (internal/modules/cjs/loader.js:708:14)
      at Module.require (internal/modules/cjs/loader.js:887:19)
      at require (internal/modules/cjs/helpers.js:74:18)
      at WebpackOptionsApply.process(/usr/share/nodejs/webpack/lib/WebpackOptionsApply.js:388:38)
      at createCompiler (/usr/share/nodejs/webpack/lib/webpack.js:80:28)
      at /usr/share/nodejs/webpack/lib/webpack.js:44:48
      at Array.map (<anonymous>)
      at createMultiCompiler (/usr/share/nodejs/webpack/lib/webpack.js:44:33)
      at create (/usr/share/nodejs/webpack/lib/webpack.js:125:16)
      at webpack (/usr/share/nodejs/webpack/lib/webpack.js:158:32)
      at f (/usr/share/nodejs/webpack/lib/index.js:58:16)
      at Context.<anonymous> (test/plugin.js:89:20)
      at callFnAsync (/usr/share/nodejs/mocha/lib/runnable.js:394:21)
      at Test.Runnable.run (/usr/share/nodejs/mocha/lib/runnable.js:338:7)
      at Runner.runTest (/usr/share/nodejs/mocha/lib/runner.js:678:10)
      at /usr/share/nodejs/mocha/lib/runner.js:801:12
      at next (/usr/share/nodejs/mocha/lib/runner.js:593:14)
      at /usr/share/nodejs/mocha/lib/runner.js:603:7
      at next (/usr/share/nodejs/mocha/lib/runner.js:486:14)
      at cbHookRun (/usr/share/nodejs/mocha/lib/runner.js:551:7)
      at done (/usr/share/nodejs/mocha/lib/runnable.js:310:5)
      at callFn (/usr/share/nodejs/mocha/lib/runnable.js:389:7)
      at Hook.Runnable.run (/usr/share/nodejs/mocha/lib/runnable.js:354:5)
      at next (/usr/share/nodejs/mocha/lib/runner.js:510:10)
      at Immediate._onImmediate (/usr/share/nodejs/mocha/lib/runner.js:571:5)
      at processImmediate (internal/timers.js:461:21)
```
Pls I will like to ask why some submodules are not exposed in this update?

I created the PR to include exporting the said file i.e  `./lib/referencer.js` 

Pls let me know if you need any other info. Thanks