### PR TITLE
chore: add triage action

### DIFF
--- a/.github/workflows/add-to-triage.yml
+++ b/.github/workflows/add-to-triage.yml
@@ -1,0 +1,18 @@
+name: Add to Triage
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/eslint/projects/3
+          github-token: ${{ secrets.PROJECT_BOT_TOKEN }}
+          labeled: "triage:no"
+          label-operator: NOT


### PR DESCRIPTION
Adds the triage GitHub action to automatically add new issues to our triage board.

Same as https://github.com/eslint/eslint/blob/main/.github/workflows/add-to-triage.yml