### PR TITLE
feat: Add isGlobalReturn method on scopeManager

### DIFF
--- a/lib/referencer.js
+++ b/lib/referencer.js
@@ -409,7 +409,7 @@ class Referencer extends esrecurse.Visitor {
     Program(node) {
         this.scopeManager.__nestGlobalScope(node);
 
-        if (this.scopeManager.__isNodejsScope()) {
+        if (this.scopeManager.isGlobalReturn()) {
 
             // Force strictness of GlobalScope to false when using node.js scope.
             this.currentScope().isStrict = false;

--- a/lib/scope-manager.js
+++ b/lib/scope-manager.js
@@ -65,7 +65,7 @@ class ScopeManager {
         return this.__options.ignoreEval;
     }
 
-    __isNodejsScope() {
+    isGlobalReturn() {
         return this.__options.nodejsScope || this.__options.sourceType === "commonjs";
     }
 

--- a/tests/nodejs-scope.js
+++ b/tests/nodejs-scope.js
@@ -38,6 +38,7 @@ describe("nodejsScope option", () => {
         const scopeManager = analyze(ast, { ecmaVersion: 6, nodejsScope: true });
 
         expect(scopeManager.scopes).to.have.length(2);
+        expect(scopeManager.isGlobalReturn()).to.be.true;
 
         let scope = scopeManager.scopes[0];
 
@@ -64,6 +65,7 @@ describe("nodejsScope option", () => {
         const scopeManager = analyze(ast, { ecmaVersion: 6, sourceType: "commonjs" });
 
         expect(scopeManager.scopes).to.have.length(2);
+        expect(scopeManager.isGlobalReturn()).to.be.true;
 
         let scope = scopeManager.scopes[0];
 
@@ -87,6 +89,7 @@ describe("nodejsScope option", () => {
         const scopeManager = analyze(ast, { ecmaVersion: 6, nodejsScope: true, sourceType: "module" });
 
         expect(scopeManager.scopes).to.have.length(3);
+        expect(scopeManager.isGlobalReturn()).to.be.true;
 
         let scope = scopeManager.scopes[0];
 


### PR DESCRIPTION
Renames the private __isNodejsScope to isGlobalReturn to formally make it part of the interface and available in ESLint.

I chose `isGlobalReturn` instead of `isNodejsScope` because the [typescript-eslint scope manager](https://github.com/typescript-eslint/typescript-eslint/blob/a4b633b9ab106e5889c2372c018b1b937ff0afbb/packages/scope-manager/src/ScopeManager.ts#L69-L71) already exposes a method called `isGlobalReturn`, so copying that would ensure that the most popular alternative scope manager already has the same method.

Refs eslint/eslint#16999