### PR TITLE
ci: run tests on Node.js v20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [19.x, 18.x, 17.x, 16.x, 14.x, 12.x, "12.22.0"]
+        node: [20.x, 19.x, 18.x, 17.x, 16.x, 14.x, 12.x, "12.22.0"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
#### What changes did you make? (Give an overview)

- run tests on Node.js v20
- Remove Node v19 and v17 from matrix

#### Is there anything you'd like reviewers to focus on?
I feel it's fine to test on even node version only.

<!-- markdownlint-disable-file MD004 -->
