### PR TITLE
docs: fix example code in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ import estraverse from 'estraverse';
 const ast = espree.parse(code, { range: true });
 const scopeManager = eslintScope.analyze(ast);
 
-const currentScope = scopeManager.acquire(ast);   // global scope
+let currentScope = scopeManager.acquire(ast);   // global scope
 
 estraverse.traverse(ast, {
     enter (node, parent) {


### PR DESCRIPTION
`currentScope` was declared as `const` in the example code, but gets reassigned.  
This is invalid.