### PR TITLE
chore: standardize npm script names

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,15 +23,17 @@
   "license": "BSD-2-Clause",
   "scripts": {
     "build": "rollup -c",
-    "lint": "npm run build && node Makefile.js lint",
-    "update-version": "node tools/update-version.js",
-    "test": "npm run build && node Makefile.js test",
-    "prepublishOnly": "npm run update-version && npm run build",
-    "generate-release": "eslint-generate-release",
-    "generate-alpharelease": "eslint-generate-prerelease alpha",
-    "generate-betarelease": "eslint-generate-prerelease beta",
-    "generate-rcrelease": "eslint-generate-prerelease rc",
-    "publish-release": "eslint-publish-release"
+    "lint": "node Makefile.js lint",
+    "prelint": "npm run build",
+    "prepublishOnly": "npm run update:version && npm run build",
+    "pretest": "npm run build",
+    "release:generate:latest": "eslint-generate-release",
+    "release:generate:alpha": "eslint-generate-prerelease alpha",
+    "release:generate:beta": "eslint-generate-prerelease beta",
+    "release:generate:rc": "eslint-generate-prerelease rc",
+    "release:publish": "eslint-publish-release",
+    "test": "node Makefile.js test",
+    "update:version": "node tools/update-version.js"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Refers https://github.com/eslint/eslint/issues/14827
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This updates the names of the scripts in package.json to be consistent with the [new standard](https://eslint.org/docs/latest/contribute/package-json-conventions).


#### Is there anything you'd like reviewers to focus on?
We may need to update the `release` related scripts on Jenkins before merging this PR.
<!-- markdownlint-disable-file MD004 -->
