### PR TITLE
feat!: use ESTree `directive` property when searching for `"use strict"`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,7 +63,6 @@ import eslintScopeVersion from "./version.js";
 function defaultOptions() {
     return {
         optimistic: false,
-        directive: false,
         nodejsScope: false,
         impliedStrict: false,
         sourceType: "script", // one of ['script', 'module', 'commonjs']
@@ -115,7 +114,6 @@ function updateDeeply(target, override) {
  * @param {espree.Tree} tree Abstract Syntax Tree
  * @param {Object} providedOptions Options that tailor the scope analysis
  * @param {boolean} [providedOptions.optimistic=false] the optimistic flag
- * @param {boolean} [providedOptions.directive=false] the directive flag
  * @param {boolean} [providedOptions.ignoreEval=false] whether to check 'eval()' calls
  * @param {boolean} [providedOptions.nodejsScope=false] whether the whole
  * script is executed under node.js environment. When enabled, escope adds

--- a/lib/scope-manager.js
+++ b/lib/scope-manager.js
@@ -53,10 +53,6 @@ class ScopeManager {
         this.__declaredVariables = new WeakMap();
     }
 
-    __useDirective() {
-        return this.__options.directive;
-    }
-
     __isOptimistic() {
         return this.__options.optimistic;
     }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -39,10 +39,9 @@ const { Syntax } = estraverse;
  * @param {Scope} scope scope
  * @param {Block} block block
  * @param {boolean} isMethodDefinition is method definition
- * @param {boolean} useDirective use directive
  * @returns {boolean} is strict scope
  */
-function isStrictScope(scope, block, isMethodDefinition, useDirective) {
+function isStrictScope(scope, block, isMethodDefinition) {
     let body;
 
     // When upper scope is exists and strict, inner scope is also strict.
@@ -82,41 +81,29 @@ function isStrictScope(scope, block, isMethodDefinition, useDirective) {
         return false;
     }
 
-    // Search 'use strict' directive.
-    if (useDirective) {
-        for (let i = 0, iz = body.body.length; i < iz; ++i) {
-            const stmt = body.body[i];
+    // Search for a 'use strict' directive.
+    for (let i = 0, iz = body.body.length; i < iz; ++i) {
+        const stmt = body.body[i];
 
-            if (stmt.type !== Syntax.DirectiveStatement) {
-                break;
-            }
-            if (stmt.raw === "\"use strict\"" || stmt.raw === "'use strict'") {
-                return true;
-            }
+        /*
+         * Check if the current statement is a directive.
+         * If it isn't, then we're past the directive prologue
+         * so stop the search because directives cannot
+         * appear after this point.
+         *
+         * Some parsers set `directive:null` on non-directive
+         * statements, so the `typeof` check is safer than
+         * checking for property existence.
+         */
+        if (typeof stmt.directive !== "string") {
+            break;
         }
-    } else {
-        for (let i = 0, iz = body.body.length; i < iz; ++i) {
-            const stmt = body.body[i];
 
-            if (stmt.type !== Syntax.ExpressionStatement) {
-                break;
-            }
-            const expr = stmt.expression;
-
-            if (expr.type !== Syntax.Literal || typeof expr.value !== "string") {
-                break;
-            }
-            if (expr.raw !== null && expr.raw !== undefined) {
-                if (expr.raw === "\"use strict\"" || expr.raw === "'use strict'") {
-                    return true;
-                }
-            } else {
-                if (expr.value === "use strict") {
-                    return true;
-                }
-            }
+        if (stmt.directive === "use strict") {
+            return true;
         }
     }
+
     return false;
 }
 
@@ -264,7 +251,7 @@ class Scope {
          * @member {boolean} Scope#isStrict
          */
         this.isStrict = scopeManager.isStrictModeSupported()
-            ? isStrictScope(this, block, isMethodDefinition, scopeManager.__useDirective())
+            ? isStrictScope(this, block, isMethodDefinition)
             : false;
 
         /**

--- a/tests/use-strict.js
+++ b/tests/use-strict.js
@@ -98,4 +98,79 @@ describe("'use strict' directives", () => {
             assertIsStrictRecursively(globalScope.childScopes[1], false); // function e() { ... }
         });
     });
+
+    it("can be with single quotes", () => {
+        getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
+            const ast = espree.parse(`
+                'use strict';
+            `, { ecmaVersion, range: true });
+
+            const { globalScope } = analyze(ast, { ecmaVersion, childVisitorKeys: KEYS });
+
+            assert.strictEqual(globalScope.isStrict, true);
+        });
+    });
+
+    it("can be without the semicolon", () => {
+        getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
+            const ast = espree.parse(`
+                "use strict"
+                foo()
+            `, { ecmaVersion, range: true });
+
+            const { globalScope } = analyze(ast, { ecmaVersion, childVisitorKeys: KEYS });
+
+            assert.strictEqual(globalScope.isStrict, true);
+        });
+    });
+
+    it("can be anywhere in the directive prologue", () => {
+        getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
+            const ast = espree.parse(`
+                "foo";
+                "use strict";
+            `, { ecmaVersion, range: true });
+
+            const { globalScope } = analyze(ast, { ecmaVersion, childVisitorKeys: KEYS });
+
+            assert.strictEqual(globalScope.isStrict, true);
+        });
+    });
+
+    it("cannot be after the directive prologue", () => {
+        getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
+            const ast = espree.parse(`
+                foo();
+                "use strict";
+            `, { ecmaVersion, range: true });
+
+            const { globalScope } = analyze(ast, { ecmaVersion, childVisitorKeys: KEYS });
+
+            assert.strictEqual(globalScope.isStrict, false);
+        });
+    });
+
+    it("cannot contain escapes", () => {
+        getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
+            const ast = espree.parse(`
+                "use \\strict";
+            `, { ecmaVersion, range: true });
+
+            const { globalScope } = analyze(ast, { ecmaVersion, childVisitorKeys: KEYS });
+
+            assert.strictEqual(globalScope.isStrict, false);
+        });
+    });
+
+    it("cannot be parenthesized", () => {
+        getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
+            const ast = espree.parse(`
+                ("use strict");
+            `, { ecmaVersion, range: true });
+
+            const { globalScope } = analyze(ast, { ecmaVersion, childVisitorKeys: KEYS });
+
+            assert.strictEqual(globalScope.isStrict, false);
+        });
+    });
 });

--- a/tests/use-strict.js
+++ b/tests/use-strict.js
@@ -99,7 +99,7 @@ describe("'use strict' directives", () => {
         });
     });
 
-    it("can be with single quotes", () => {
+    it("can be with single quotes at the top level", () => {
         getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
             const ast = espree.parse(`
                 'use strict';
@@ -111,7 +111,7 @@ describe("'use strict' directives", () => {
         });
     });
 
-    it("can be without the semicolon", () => {
+    it("can be without the semicolon at the top level", () => {
         getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
             const ast = espree.parse(`
                 "use strict"
@@ -124,7 +124,7 @@ describe("'use strict' directives", () => {
         });
     });
 
-    it("can be anywhere in the directive prologue", () => {
+    it("can be anywhere in the directive prologue at the top level", () => {
         getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
             const ast = espree.parse(`
                 "foo";
@@ -137,7 +137,7 @@ describe("'use strict' directives", () => {
         });
     });
 
-    it("cannot be after the directive prologue", () => {
+    it("cannot be after the directive prologue at the top level", () => {
         getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
             const ast = espree.parse(`
                 foo();
@@ -150,7 +150,7 @@ describe("'use strict' directives", () => {
         });
     });
 
-    it("cannot contain escapes", () => {
+    it("cannot contain escapes at the top level", () => {
         getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
             const ast = espree.parse(`
                 "use \\strict";
@@ -162,7 +162,7 @@ describe("'use strict' directives", () => {
         });
     });
 
-    it("cannot be parenthesized", () => {
+    it("cannot be parenthesized at the top level", () => {
         getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
             const ast = espree.parse(`
                 ("use strict");
@@ -171,6 +171,111 @@ describe("'use strict' directives", () => {
             const { globalScope } = analyze(ast, { ecmaVersion, childVisitorKeys: KEYS });
 
             assert.strictEqual(globalScope.isStrict, false);
+        });
+    });
+
+    it("can be with single quotes in a function", () => {
+        getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
+            const ast = espree.parse(`
+                function foo() {
+                    'use strict';
+                }
+            `, { ecmaVersion, range: true });
+
+            const { globalScope } = analyze(ast, { ecmaVersion, childVisitorKeys: KEYS });
+
+            assert.strictEqual(globalScope.isStrict, false);
+            assert.strictEqual(globalScope.childScopes.length, 1);
+            assert.strictEqual(globalScope.childScopes[0].type, "function");
+            assert.strictEqual(globalScope.childScopes[0].isStrict, true);
+        });
+    });
+
+    it("can be without the semicolon in a function", () => {
+        getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
+            const ast = espree.parse(`
+                function foo() {
+                    "use strict"
+                    bar()
+                }
+            `, { ecmaVersion, range: true });
+
+            const { globalScope } = analyze(ast, { ecmaVersion, childVisitorKeys: KEYS });
+
+            assert.strictEqual(globalScope.isStrict, false);
+            assert.strictEqual(globalScope.childScopes.length, 1);
+            assert.strictEqual(globalScope.childScopes[0].type, "function");
+            assert.strictEqual(globalScope.childScopes[0].isStrict, true);
+        });
+    });
+
+    it("can be anywhere in the directive prologue in a function", () => {
+        getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
+            const ast = espree.parse(`
+                function foo() {
+                    "foo";
+                    "use strict";
+                }
+            `, { ecmaVersion, range: true });
+
+            const { globalScope } = analyze(ast, { ecmaVersion, childVisitorKeys: KEYS });
+
+            assert.strictEqual(globalScope.isStrict, false);
+            assert.strictEqual(globalScope.childScopes.length, 1);
+            assert.strictEqual(globalScope.childScopes[0].type, "function");
+            assert.strictEqual(globalScope.childScopes[0].isStrict, true);
+        });
+    });
+
+    it("cannot be after the directive prologue in a function", () => {
+        getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
+            const ast = espree.parse(`
+                function foo() {
+                    bar();
+                    "use strict";
+                }
+            `, { ecmaVersion, range: true });
+
+            const { globalScope } = analyze(ast, { ecmaVersion, childVisitorKeys: KEYS });
+
+            assert.strictEqual(globalScope.isStrict, false);
+            assert.strictEqual(globalScope.childScopes.length, 1);
+            assert.strictEqual(globalScope.childScopes[0].type, "function");
+            assert.strictEqual(globalScope.childScopes[0].isStrict, false);
+        });
+    });
+
+    it("cannot contain escapes in a function", () => {
+        getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
+            const ast = espree.parse(`
+                function foo() {
+                    "use \\strict";
+                }
+            `, { ecmaVersion, range: true });
+
+            const { globalScope } = analyze(ast, { ecmaVersion, childVisitorKeys: KEYS });
+
+            assert.strictEqual(globalScope.isStrict, false);
+            assert.strictEqual(globalScope.childScopes.length, 1);
+            assert.strictEqual(globalScope.childScopes[0].type, "function");
+            assert.strictEqual(globalScope.childScopes[0].isStrict, false);
+        });
+    });
+
+    it("cannot be parenthesized in a function", () => {
+        getSupportedEcmaVersions({ min: 5 }).forEach(ecmaVersion => {
+            const ast = espree.parse(`
+                function foo() {
+                    ("use strict");
+                }
+            `, { ecmaVersion, range: true });
+
+            const { globalScope } = analyze(ast, { ecmaVersion, childVisitorKeys: KEYS });
+
+            assert.strictEqual(globalScope.isStrict, false);
+            assert.strictEqual(globalScope.childScopes.length, 1);
+            assert.strictEqual(globalScope.childScopes[0].type, "function");
+            assert.strictEqual(globalScope.childScopes[0].isStrict, false);
         });
     });
 });


### PR DESCRIPTION
Fixes #117

Updates the code that searches for `"use strict"` directives to use the [`directive` property](https://github.com/estree/estree/blob/master/es5.md#directive) as the only way to determine whether a node represents a directive. All other ways are dropped, as it is expected that the given AST follows the ESTree Spec.

Option `directive` that was enabling the use of non-standard DirectiveStatement nodes is also dropped.

The `("use strict");` test demonstrates the behavior change. The other tests are added as regression tests, they were already passing before this change.