### PR TITLE
docs: document Security Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ estraverse.traverse(ast, {
 
 Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](http://eslint.org/docs/developer-guide/contributing), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/eslint-scope/issues).
 
+## Security Policy
+
+We work hard to ensure that ESLint Scope is safe for everyone and that security issues are addressed quickly and responsibly. Read the full [security policy](https://github.com/eslint/.github/blob/master/SECURITY.md).
+
 ## Build Commands
 
 * `npm test` - run all linting and tests


### PR DESCRIPTION
This PR adds a "Security Policy" section to the readme file, like those in the [eslint](https://github.com/eslint/eslint/blob/5251327711a2d7083e3c629cb8e48d9d1e809add/README.md?plain=1#L160-L162) and [espree](https://github.com/eslint/espree/blob/b0767ef7ba6979a1005c93c49c41aff1af483e07/README.md?plain=1#L180-L182) repos.

Tidelift recommends [creating a discoverable security policy](https://support.tidelift.com/hc/en-us/articles/11781961573012-Create-a-discoverable-security-policy) for registered packages. Once we have added the relevant information and the link to the readme file, we will be able to set the readme file as a discoverable security policy for eslint-scope in Tidelift. eslint and espree already have this setting.