### PR TITLE
chore: update dependency shelljs to ^0.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "mocha": "^9.0.1",
     "npm-license": "^0.3.3",
     "rollup": "^2.52.7",
-    "shelljs": "^0.8.4",
+    "shelljs": "^0.8.5",
     "typescript": "^5.4.2"
   }
 }


### PR DESCRIPTION
Versions of shelljs prior to v0.8.5 are affected by a high rated security vulnerability. It's unlikely that anyone working with this repo has one of those older versions installed, but they are not automatically updated as long as they match the version range in package.json. This PR updates package.json to ensure that only shelljs ^0.8.5 is used.

NVD advisory: https://nvd.nist.gov/vuln/detail/CVE-2022-0144