### PR TITLE
fix: `Definition#name` in catch patterns should be `Identifier` node

### DIFF
--- a/lib/referencer.js
+++ b/lib/referencer.js
@@ -395,7 +395,7 @@ class Referencer extends esrecurse.Visitor {
             this.currentScope().__define(pattern,
                 new Definition(
                     Variable.CatchClause,
-                    node.param,
+                    pattern,
                     node,
                     null,
                     null,

--- a/tests/catch-scope.js
+++ b/tests/catch-scope.js
@@ -56,8 +56,83 @@ describe("catch", () => {
         expect(scope.type).to.be.equal("catch");
         expect(scope.variables).to.have.length(1);
         expect(scope.variables[0].name).to.be.equal("e");
+        expect(scope.variables[0].defs).to.have.length(1);
+        expect(scope.variables[0].defs[0].type).to.be.equal("CatchClause");
+        expect(scope.variables[0].defs[0].name.type).to.be.equal("Identifier");
+        expect(scope.variables[0].defs[0].name.name).to.be.equal("e");
+        expect(scope.variables[0].defs[0].node.type).to.be.equal("CatchClause");
+        expect(scope.variables[0].defs[0].parent).to.be.equal(null);
         expect(scope.isArgumentsMaterialized()).to.be.true;
         expect(scope.references).to.have.length(0);
+    });
+
+    it("param can be a pattern", () => {
+        const ast = espree(`
+            (function () {
+                const default_id = 0;
+                try {
+                } catch ({ message, id = default_id, args: [arg1, arg2] }) {
+                }
+            }());
+        `);
+
+        const scopeManager = analyze(ast);
+
+        expect(scopeManager.scopes).to.have.length(3);
+
+        const globalScope = scopeManager.scopes[0];
+
+        expect(globalScope.type).to.be.equal("global");
+        expect(globalScope.variables).to.have.length(0);
+        expect(globalScope.references).to.have.length(0);
+
+        const functionScope = scopeManager.scopes[1];
+
+        expect(functionScope.type).to.be.equal("function");
+        expect(functionScope.variables).to.have.length(2);
+        expect(functionScope.variables[0].name).to.be.equal("arguments");
+        expect(functionScope.variables[1].name).to.be.equal("default_id");
+        expect(functionScope.references).to.have.length(1);
+        expect(functionScope.references[0].from).to.be.equal(functionScope);
+        expect(functionScope.references[0].resolved).to.be.equal(functionScope.variables[1]);
+
+        const catchScope = scopeManager.scopes[2];
+
+        expect(catchScope.type).to.be.equal("catch");
+        expect(catchScope.variables).to.have.length(4);
+        expect(catchScope.variables[0].name).to.be.equal("message");
+        expect(catchScope.variables[0].defs).to.have.length(1);
+        expect(catchScope.variables[0].defs[0].type).to.be.equal("CatchClause");
+        expect(catchScope.variables[0].defs[0].name.type).to.be.equal("Identifier");
+        expect(catchScope.variables[0].defs[0].name.name).to.be.equal("message");
+        expect(catchScope.variables[0].defs[0].node.type).to.be.equal("CatchClause");
+        expect(catchScope.variables[0].defs[0].parent).to.be.equal(null);
+        expect(catchScope.variables[1].name).to.be.equal("id");
+        expect(catchScope.variables[1].defs).to.have.length(1);
+        expect(catchScope.variables[1].defs[0].type).to.be.equal("CatchClause");
+        expect(catchScope.variables[1].defs[0].name.type).to.be.equal("Identifier");
+        expect(catchScope.variables[1].defs[0].name.name).to.be.equal("id");
+        expect(catchScope.variables[1].defs[0].node.type).to.be.equal("CatchClause");
+        expect(catchScope.variables[1].defs[0].parent).to.be.equal(null);
+        expect(catchScope.variables[2].name).to.be.equal("arg1");
+        expect(catchScope.variables[2].defs).to.have.length(1);
+        expect(catchScope.variables[2].defs[0].type).to.be.equal("CatchClause");
+        expect(catchScope.variables[2].defs[0].name.type).to.be.equal("Identifier");
+        expect(catchScope.variables[2].defs[0].name.name).to.be.equal("arg1");
+        expect(catchScope.variables[2].defs[0].node.type).to.be.equal("CatchClause");
+        expect(catchScope.variables[2].defs[0].parent).to.be.equal(null);
+        expect(catchScope.variables[3].name).to.be.equal("arg2");
+        expect(catchScope.variables[3].defs).to.have.length(1);
+        expect(catchScope.variables[3].defs[0].type).to.be.equal("CatchClause");
+        expect(catchScope.variables[3].defs[0].name.type).to.be.equal("Identifier");
+        expect(catchScope.variables[3].defs[0].name.name).to.be.equal("arg2");
+        expect(catchScope.variables[3].defs[0].node.type).to.be.equal("CatchClause");
+        expect(catchScope.variables[3].defs[0].parent).to.be.equal(null);
+        expect(catchScope.references).to.have.length(2);
+        expect(catchScope.references[0].from).to.be.equal(catchScope);
+        expect(catchScope.references[0].resolved).to.be.equal(catchScope.variables[1]);
+        expect(catchScope.references[1].from).to.be.equal(catchScope);
+        expect(catchScope.references[1].resolved).to.be.equal(functionScope.variables[1]);
     });
 });
 

--- a/tests/catch-scope.js
+++ b/tests/catch-scope.js
@@ -76,9 +76,9 @@ describe("catch", () => {
             }());
         `);
 
-        const scopeManager = analyze(ast);
+        const scopeManager = analyze(ast, { ecmaVersion: 6 });
 
-        expect(scopeManager.scopes).to.have.length(3);
+        expect(scopeManager.scopes).to.have.length(5);
 
         const globalScope = scopeManager.scopes[0];
 
@@ -96,7 +96,13 @@ describe("catch", () => {
         expect(functionScope.references[0].from).to.be.equal(functionScope);
         expect(functionScope.references[0].resolved).to.be.equal(functionScope.variables[1]);
 
-        const catchScope = scopeManager.scopes[2];
+        const tryBlockScope = scopeManager.scopes[2];
+
+        expect(tryBlockScope.type).to.be.equal("block");
+        expect(tryBlockScope.variables).to.have.length(0);
+        expect(tryBlockScope.references).to.have.length(0);
+
+        const catchScope = scopeManager.scopes[3];
 
         expect(catchScope.type).to.be.equal("catch");
         expect(catchScope.variables).to.have.length(4);
@@ -133,6 +139,12 @@ describe("catch", () => {
         expect(catchScope.references[0].resolved).to.be.equal(catchScope.variables[1]);
         expect(catchScope.references[1].from).to.be.equal(catchScope);
         expect(catchScope.references[1].resolved).to.be.equal(functionScope.variables[1]);
+
+        const catchBlockScope = scopeManager.scopes[4];
+
+        expect(catchBlockScope.type).to.be.equal("block");
+        expect(catchBlockScope.variables).to.have.length(0);
+        expect(catchBlockScope.references).to.have.length(0);
     });
 });
 


### PR DESCRIPTION
Refs https://github.com/eslint/eslint/pull/18636#pullrequestreview-2150587740

Currently, if catch param is a pattern, `Definition#name` of variables created in the pattern points to the pattern instead of the Identifier nodes.

Repro:

```js
import * as eslintScope from 'eslint-scope';
import * as espree from 'espree';

const code = "try {} catch({ message }) {}";

const ast = espree.parse(code, { range: true, ecmaVersion: 2015 });
const scopeManager = eslintScope.analyze(ast, { ecmaVersion: 2015 });

const catchScope = scopeManager.scopes[2];
const variable = catchScope.variables[0];

console.log(variable.name); // "message"

console.log(variable.defs[0].name.type); // "ObjectPattern" !

```


This fixes the mentioned Definitions to point to Identifier nodes.

I've verified that all tests in eslint/eslint are still passing after this change. All new tests added in https://github.com/eslint/eslint/pull/18636 are also passing after this change.